### PR TITLE
Fixed PHP version breaking for other locales

### DIFF
--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -40,7 +40,7 @@ install_mariadb() {
   elif [[ "${VERSION_CODENAME}" == "bullseye" ]];then
     USER=${USER} ${my_dir}/createdb_bullseye.sh
   fi
-  systemctl restart php7.${php_version}-fpm
+  systemctl restart php${php_version}-fpm
 }
 
 install_birdnet_analysis() {
@@ -231,7 +231,7 @@ install_Caddyfile() {
   if [ -f /etc/caddy/Caddyfile ];then
     cp /etc/caddy/Caddyfile{,.original}
   fi
-  php_version="$(awk -F. '{print $2}' <(ls -l $(which /etc/alternatives/php)))"
+  php_version="$(awk -F'php' '{print $3}' <(ls -l $(which /etc/alternatives/php)))"
   HASHWORD=$(caddy hash-password -plaintext ${CADDY_PWD})
   cat << EOF > /etc/caddy/Caddyfile
 http://localhost http://birdnetpi.local ${BIRDNETPI_URL} {
@@ -250,7 +250,7 @@ http://localhost http://birdnetpi.local ${BIRDNETPI_URL} {
     birdnet ${HASHWORD}
   }
   reverse_proxy /stream localhost:8000
-  php_fastcgi unix//run/php/php7.${php_version}-fpm.sock
+  php_fastcgi unix//run/php/php${php_version}-fpm.sock
 }
 EOF
   if [ ! -z ${EXTRACTIONLOG_URL} ];then

--- a/scripts/update_services.sh
+++ b/scripts/update_services.sh
@@ -228,7 +228,7 @@ install_Caddyfile() {
   if [ -f /etc/caddy/Caddyfile ];then
     cp /etc/caddy/Caddyfile{,.original}
   fi
-  php_version="$(awk -F. '{print $2}' <(ls -l $(which /etc/alternatives/php)))"
+  php_version="$(awk -F'php' '{print $3}' <(ls -l $(which /etc/alternatives/php)))"
   HASHWORD=$(caddy hash-password -plaintext ${CADDY_PWD})
   cat << EOF > /etc/caddy/Caddyfile
 http://localhost http://birdnetpi.local ${BIRDNETPI_URL} {
@@ -247,7 +247,7 @@ http://localhost http://birdnetpi.local ${BIRDNETPI_URL} {
     birdnet ${HASHWORD}
   }
   reverse_proxy /stream localhost:8000
-  php_fastcgi unix//run/php/php7.${php_version}-fpm.sock
+  php_fastcgi unix//run/php/php${php_version}-fpm.sock
 }
 EOF
   if [ ! -z ${EXTRACTIONLOG_URL} ];then
@@ -539,7 +539,7 @@ install_selected_services() {
   create_necessary_dirs
   generate_BirdDB
   install_cleanup_cron
-  systemctl restart php7.${php_version}-fpm
+  systemctl restart php${php_version}-fpm
 }
 
 if [ -f ${config_file} ];then 


### PR DESCRIPTION
OLD
php_version="$(awk -F. '{print $2}' <(ls -l $(which /etc/alternatives/php)))"
NEW
php_version="$(awk -F'php' '{print $3}' <(ls -l $(which /etc/alternatives/php)))"