### PR TITLE
Use jq for processing JSON when figuring out latitude/longitude

### DIFF
--- a/newinstaller.sh
+++ b/newinstaller.sh
@@ -6,11 +6,18 @@ USER=$USER
 export HOME=$HOME
 export USER=$USER
 
-branch=main
-if ! which git &> /dev/null;then
+PACKAGES_MISSING=
+for cmd in git jq ; do
+  if ! which $cmd &> /dev/null;then
+      PACKAGES_MISSING="${PACKAGES_MISSING} $cmd"
+  fi
+done
+if [[ ! -z $PACKAGES_MISSING ]] ; then
   sudo apt update
-  sudo apt -y install git
+  sudo apt -y install $PACKAGES_MISSING
 fi
+
+branch=main
 git clone -b $branch https://github.com/mcguirepr89/BirdNET-Pi.git ${HOME}/BirdNET-Pi &&
 
 $HOME/BirdNET-Pi/scripts/install_birdnet.sh

--- a/scripts/install_config.sh
+++ b/scripts/install_config.sh
@@ -19,8 +19,8 @@ install_config() {
 ## TO BE CHANGED TO STATIC VALUES
 ## Please only go to 4 decimal places. Example:43.3984
 
-LATITUDE=$(curl -s4 ifconfig.co/json | awk '/latitude/ {print $2}' | tr -d ',')
-LONGITUDE=$(curl -s4 ifconfig.co/json | awk '/longitude/ {print $2}' | tr -d ',')
+LATITUDE=$(curl -s4 ifconfig.co/json | jq .latitude)
+LONGITUDE=$(curl -s4 ifconfig.co/json | jq .longitude)
 
 #---------------------  BirdWeather Station Information -----------------------#
 #_____________The variable below can be set to have your BirdNET-Pi____________#


### PR DESCRIPTION
# What's here?

In `scripts/install_config.sh`, we are currently figuring out latitude and longitude like so:

```
LATITUDE=$(curl -s4 ifconfig.co/json | awk '/latitude/ {print $2}' | tr -d ',')
LONGITUDE=$(curl -s4 ifconfig.co/json | awk '/longitude/ {print $2}' | tr -d ',')
```

This PR uses [`jq`](https://stedolan.github.io/jq/) to do this, rather than `awk` and `tr` .  If you haven't come across it before, `jq` allows you to process JSON quite easily.  In the case of the output we get from ifconfig.co, the command is quite simple:

```shell
birdnetpi:~/BirdNET-Pi/scripts$ curl -s4 ifconfig.co/json | jq .latitude
49.1906
birdnetpi:~/BirdNET-Pi/scripts$ curl -s4 ifconfig.co/json | jq .longitude
-122.9344
```

jq is already packaged for Debian/Raspian (and just about any other Linux distro), so it's easy enough to install.  Because it comprehends JSON natively, it allows us to directly address the part of JSON that we want.  And it's a small package (64 kBytes), so adding it to the system won't take up any significant space.

To make sure `jq` is installed along with `git`, I've also refactored the package install a bit:
```bash
PACKAGES_MISSING=
for cmd in git jq ; do
  if ! which $cmd &> /dev/null;then
      PACKAGES_MISSING="${PACKAGES_MISSING} $cmd"
  fi
done
if [[ ! -z $PACKAGES_MISSING ]] ; then
  sudo apt update
  sudo apt -y install $PACKAGES_MISSING
fi
```

However, I imagine it would be just as simple to unconditionally install both.

# Testing

## Setting latitude/longitude

I broke out the changes I made into their own script:

```bash
#!/bin/bash
LATITUDE=$(curl -s4 ifconfig.co/json | jq .latitude)
LONGITUDE=$(curl -s4 ifconfig.co/json | jq .longitude)

echo "Latitude: $LATITUDE"
echo "Longitue: $LONGITUDE"
```

Here's the output:

```
$ ./test.sh 
Latitude: 49.1906
Longitue: -122.9344
```
## Checking for jq

As above, I broke out my changes into a test script:

```bash
#!/bin/bash -x

PACKAGES_MISSING=
for cmd in git jq ; do
  if ! which $cmd &> /dev/null;then
      PACKAGES_MISSING="${PACKAGES_MISSING} $cmd"
  fi
done
if [[ ! -z $PACKAGES_MISSING ]] ; then
  sudo apt update
  sudo apt -y install $PACKAGES_MISSING
fi 
```

Happy case, both `git` and `jq` present:

```bash
./test2.sh 
+ PACKAGES_MISSING=
+ for cmd in git jq
+ which git
+ for cmd in git jq
+ which jq
+ [[ ! -z '' ]]
```

`git` missing:

```bash
$ ./test2.sh 
+ PACKAGES_MISSING=
+ for cmd in git jq
+ which git
+ PACKAGES_MISSING=' git'
+ for cmd in git jq
+ which jq
+ [[ ! -z  git ]]
+ sudo apt update
Hit:1 http://security.debian.org/debian-security bullseye-security InRelease
Hit:2 http://deb.debian.org/debian bullseye InRelease                                                                            
Hit:3 http://deb.debian.org/debian bullseye-updates InRelease                                                                    
Hit:4 http://archive.raspberrypi.org/debian bullseye InRelease                                                                   
Get:5 https://dl.cloudsmith.io/public/caddy/stable/deb/debian bullseye InRelease [7,485 B]                 
Fetched 7,485 B in 2s (4,778 B/s)    
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
20 packages can be upgraded. Run 'apt list --upgradable' to see them.
+ sudo apt -y install git
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Suggested packages:
  git-daemon-run | git-daemon-sysvinit git-doc git-el git-email git-gui gitk gitweb git-cvs git-mediawiki git-svn
The following NEW packages will be installed:
  git
[snip]
```

Both missing:

```bash
+ PACKAGES_MISSING=
+ for cmd in git jq
+ which git
+ PACKAGES_MISSING=' git'
+ for cmd in git jq
+ which jq
+ PACKAGES_MISSING=' git jq'
+ [[ ! -z  git jq ]]
+ sudo apt update
Hit:1 http://security.debian.org/debian-security bullseye-security InRelease
Hit:2 http://deb.debian.org/debian bullseye InRelease                                                          
Hit:3 http://deb.debian.org/debian bullseye-updates InRelease                                                  
Get:4 https://dl.cloudsmith.io/public/caddy/stable/deb/debian bullseye InRelease [7,485 B]                     
Hit:5 http://archive.raspberrypi.org/debian bullseye InRelease                                            
Fetched 7,485 B in 2s (4,749 B/s)                          
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
20 packages can be upgraded. Run 'apt list --upgradable' to see them.
+ sudo apt -y install git jq
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Suggested packages:
  git-daemon-run | git-daemon-sysvinit git-doc git-el git-email git-gui gitk gitweb git-cvs git-mediawiki git-svn
The following NEW packages will be installed:
  git jq
0 upgraded, 2 newly installed, 0 to remove and 20 not upgraded.
Need to get 0 B/5,493 kB of archives.
[snip]
```

Signed-off-by: Hugh Brown (Saint Aardvark the Carpeted) <aardvark@saintaardvarkthecarpeted.com>