### PR TITLE
Adding python flak8 linting to CI for .py files only

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,30 @@
+name: Python CI
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**.py'
+
+jobs:
+  python-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.9.x'
+          cache: 'pip'
+          architecture: 'x64'
+
+      - name: Install flake8
+        run: pip install flake8
+
+      - name: Run Flake8 Lint
+        run: |
+          DIFF="$(git --no-pager diff -u $(git merge-base HEAD origin/main) -- '**/*.py')"
+          echo "$DIFF" | flake8 --diff


### PR DESCRIPTION
Hello, Back again 👋 

Since you were interested in some linting protection for the python files I figured I'd work up a github-action that only runs on python files and only tests the diff'd lines.

This way, going forward, you can enforce new lines or lines changed in python files to be linted, but we don't have to go clean up the linting errors on all existing python files to begin with.

