### PR TITLE
Fixing bug in Caddyfile with the '/views.php?view=File*' path.

### DIFF
--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -212,7 +212,7 @@ http://localhost http://$(hostname).local ${BIRDNETPI_URL} {
   handle /Charts/* {
     file_server browse
   }
-  basicauth views.php?view=File* {
+  basicauth /views.php?view=File* {
     birdnet ${HASHWORD}
   }
   basicauth /Processed* {

--- a/scripts/update_caddyfile.sh
+++ b/scripts/update_caddyfile.sh
@@ -18,7 +18,7 @@ http://localhost http://$(hostname).local ${BIRDNETPI_URL} {
   handle /Charts/* {
     file_server browse
   }
-  basicauth views.php?view=File* {
+  basicauth /views.php?view=File* {
     birdnet ${HASHWORD}
   }
   basicauth /Processed* {


### PR DESCRIPTION
I had a fresh birdnet-pi install yesterday and realized the Caddyfile configuration being generated was invalid.

Caddyfile expects all path specific 'matchers' to begin with a '/'
https://caddyserver.com/docs/caddyfile/matchers#syntax

Caddyfile Validation without this leading `/` results in:

```
birdnetpi:~/BirdNET-Pi$ ag -A 2 views.php /etc/caddy/Caddyfile
11:	basicauth views.php?view=File* {
12-		birdnet JDJhJDE0JGUxU2gud1N1U0VGUjZiR3dYYWVKcE9kOC9JY1BtTUhSUExoN2RMNC85M2VFSlVWSzJ5RUZt
13-	}
birdnetpi:~/BirdNET-Pi$ caddy validate --config /etc/caddy/Caddyfile
2022/05/15 17:13:17.681	INFO	using provided configuration	{"config_file": "/etc/caddy/Caddyfile", "config_adapter": ""}
validate: adapting config using caddyfile: parsing caddyfile tokens for 'basicauth': /etc/caddy/Caddyfile:11 - Error during parsing: unrecognized hash algorithm: views.php?view=File*
```

This parsing error also shows up on caddy service restarts:
```
28290-May 14 18:40:31 birdnetpi systemd[1]: Reloading Caddy.
28291-May 14 18:40:31 birdnetpi caddy[97884]: {"level":"info","ts":1652568031.2107668,"msg":"using provided configuration","config_file":"/etc/caddy/Caddyfile","config_adapter":""}
28292:May 14 18:40:31 birdnetpi caddy[97884]: reload: adapting config using caddyfile: parsing caddyfile tokens for 'basicauth': /etc/caddy/Caddyfile:10 - Error during parsing: unrecognized hash algorithm: views.php?view=File*
28293-May 14 18:40:31 birdnetpi systemd[1]: pushed_notifications.service: Scheduled restart job, restart counter is at 2481.
28294-May 14 18:40:31 birdnetpi systemd[1]: caddy.service: Control process exited, code=exited, status=1/FAILURE
```

This PR should correct these issues going forward.