### PR TITLE
Updating CADDY_PWD config updating to allow special characters

### DIFF
--- a/scripts/advanced.php
+++ b/scripts/advanced.php
@@ -33,12 +33,11 @@ if(isset($_GET['submit'])) {
   if(isset($_GET["caddy_pwd"])) {
     $caddy_pwd = $_GET["caddy_pwd"];
     if(strcmp($caddy_pwd,$config['CADDY_PWD']) !== 0) {
-      $contents = preg_replace("/CADDY_PWD=.*/", "CADDY_PWD=$caddy_pwd", $contents);
-      $contents2 = preg_replace("/CADDY_PWD=.*/", "CADDY_PWD=$caddy_pwd", $contents2);
+      $contents = preg_replace("/CADDY_PWD=.*/", "CADDY_PWD=\"$caddy_pwd\"", $contents);
       $fh = fopen('/etc/birdnet/birdnet.conf', "w");
       $fh2 = fopen("./scripts/thisrun.txt", "w");
       fwrite($fh, $contents);
-      fwrite($fh2, $contents2);
+      fwrite($fh2, $contents);
       exec('sudo /usr/local/bin/update_caddyfile.sh > /dev/null 2>&1 &');
     }
   }

--- a/scripts/advanced.php
+++ b/scripts/advanced.php
@@ -38,7 +38,7 @@ if(isset($_GET['submit'])) {
       $fh = fopen('/etc/birdnet/birdnet.conf', "w");
       $fh2 = fopen("./scripts/thisrun.txt", "w");
       fwrite($fh, $contents);
-      fwrite($fh2, $contents);
+      fwrite($fh2, $contents2);
       exec('sudo /usr/local/bin/update_caddyfile.sh > /dev/null 2>&1 &');
     }
   }

--- a/scripts/advanced.php
+++ b/scripts/advanced.php
@@ -34,7 +34,7 @@ if(isset($_GET['submit'])) {
     $caddy_pwd = $_GET["caddy_pwd"];
     if(strcmp($caddy_pwd,$config['CADDY_PWD']) !== 0) {
       $contents = preg_replace("/CADDY_PWD=.*/", "CADDY_PWD=\"$caddy_pwd\"", $contents);
-      $contents2 = preg_replace("/CADDY_PWD=.*/", "CADDY_PWD=\"$caddy_pwd\"", $contents);
+      $contents2 = preg_replace("/CADDY_PWD=.*/", "CADDY_PWD=\"$caddy_pwd\"", $contents2);
       $fh = fopen('/etc/birdnet/birdnet.conf', "w");
       $fh2 = fopen("./scripts/thisrun.txt", "w");
       fwrite($fh, $contents);

--- a/scripts/advanced.php
+++ b/scripts/advanced.php
@@ -34,6 +34,7 @@ if(isset($_GET['submit'])) {
     $caddy_pwd = $_GET["caddy_pwd"];
     if(strcmp($caddy_pwd,$config['CADDY_PWD']) !== 0) {
       $contents = preg_replace("/CADDY_PWD=.*/", "CADDY_PWD=\"$caddy_pwd\"", $contents);
+      $contents2 = preg_replace("/CADDY_PWD=.*/", "CADDY_PWD=\"$caddy_pwd\"", $contents);
       $fh = fopen('/etc/birdnet/birdnet.conf', "w");
       $fh2 = fopen("./scripts/thisrun.txt", "w");
       fwrite($fh, $contents);


### PR DESCRIPTION
Currently, the CADDY_PWD logic writes the password string plaintext into `birdnet.conf`, but if that password string contains any special characters then it could break sourcing the config file:

```
birdnetpi:~/BirdNET-Pi$ cat testing
TESTING=asdf&&&sdfsdf
birdnetpi:~/BirdNET-Pi$ source testing
-bash: testing: line 1: syntax error near unexpected token `&'
-bash: testing: line 1: `TESTING=asdf&&&sdfsdf'
birdnetpi:~/BirdNET-Pi$

..... 

birdnetpi:~/BirdNET-Pi$ cat testing
TESTING="asdf&&&sdfsdf"
birdnetpi:~/BirdNET-Pi$ source testing
birdnetpi:~/BirdNET-Pi$
```

This change should protect against  https://github.com/mcguirepr89/BirdNET-Pi/issues/276