### PR TITLE
Makes this thing actually work!

### DIFF
--- a/scripts/extract_new_birdsounds.sh
+++ b/scripts/extract_new_birdsounds.sh
@@ -117,7 +117,7 @@ for h in "${SCAN_DIRS[@]}";do
     fi
 
     sox "${h}/${OLDFILE}" "${NEWSPECIES_BYDATE}/${NEWFILE}" \
-      trim "${START}" "${END}"
+      trim ="${START}" ="${END}"
 
     # Create spectrogram for extraction
     sox "${NEWSPECIES_BYDATE}/${NEWFILE}" -n remix 1 rate 24k spectrogram \


### PR DESCRIPTION
In `sox`, the default syntax `trim` uses for `position` is `+`. This means it is necessary to specify the `=` symbol to get the proper syntax for the `trim` call.