### PR TITLE
Updating python shebangs to use /usr/bin/env python3

### DIFF
--- a/scripts/update_birdnet_snippets.sh
+++ b/scripts/update_birdnet_snippets.sh
@@ -7,7 +7,7 @@ HOME=$(awk -F: '/1000/ {print $6}' /etc/passwd)
 my_dir=$HOME/BirdNET-Pi/scripts
 if ! grep python3 <(head -n1 $my_dir/analyze.py) &>/dev/null;then
   echo "Ensure all python scripts use the virtual environment"
-  sudo -u$USER sed -si "1 i\\#\!$HOME/BirdNET-Pi/birdnet/bin/python3" $my_dir/*.py
+  sudo -u$USER sed -si "1 i\\#\!/usr/bin/env python3" $my_dir/*.py
 fi
 if ! grep PRIVACY_THRESHOLD /etc/birdnet/birdnet.conf &>/dev/null;then
   sudo -u$USER echo "PRIVACY_THRESHOLD=0" >> /etc/birdnet/birdnet.conf


### PR DESCRIPTION
One of the sources of local modifications that `git` sees is the python shebang in python scripts that is injected by this script.

I don't see a reason why we can't use `#!/usr/bin/env python3`, so I've updated the script to use that.  If we're able to use that, then we can [hardcode that shebang into the python scripts](https://github.com/mcguirepr89/BirdNET-Pi/compare/main...jmherbst:fix-python-shebangs?expand=1) and remove this conditional entirely.

This is related to https://github.com/mcguirepr89/BirdNET-Pi/discussions/282#discussioncomment-2762883
Thoughts? 