### PR TITLE
Use posix sh compatible redirect in crontab

### DIFF
--- a/templates/cleanup.cron
+++ b/templates/cleanup.cron
@@ -1,6 +1,6 @@
 #birdnet
-*/5 * * * * $USER /usr/local/bin/disk_check.sh &> /dev/null
+*/5 * * * * $USER /usr/local/bin/disk_check.sh >/dev/null 2>&1
 #birdnet
-*/3 * * * * $USER /usr/local/bin/cleanup.sh &> /dev/null
+*/3 * * * * $USER /usr/local/bin/cleanup.sh >/dev/null 2>&1
 #birdnet
-@reboot $USER /usr/local/bin/cleanup.sh &> /dev/null
+@reboot $USER /usr/local/bin/cleanup.sh >/dev/null 2>&1


### PR DESCRIPTION
&> is a bash shortcut to redirect both stdout and stderr
it is more portable to use '>/dev/null 2>&1' to achieve this effect.

Without this change the pi mailbox is filled with cron job output