### PR TITLE
Making restart_services.sh faster and more consistent

### DIFF
--- a/scripts/restart_services.sh
+++ b/scripts/restart_services.sh
@@ -4,23 +4,48 @@ source /etc/birdnet/birdnet.conf
 set -x
 my_dir=$HOME/BirdNET-Pi/scripts
 
+
 sudo systemctl stop birdnet_server.service
-sudo pkill server.py
 sudo systemctl stop birdnet_recording.service
+
 services=(web_terminal.service
-spectrogram_viewer.service
-livestream.service
-icecast2.service
-extraction.service
-chart_viewer.service
-birdnet_recording.service
-birdnet_log.service)
+  spectrogram_viewer.service
+  livestream.service
+  icecast2.service
+  extraction.service
+  chart_viewer.service
+  birdnet_recording.service
+  birdnet_log.service)
 
 for i in  "${services[@]}";do
-sudo systemctl restart "${i}"
+  sudo systemctl restart "${i}"
 done
-until grep 5050 <(netstat -tulpn 2>&1);do
-sudo systemctl restart birdnet_server.service
-sleep 45
+
+sudo systemctl start birdnet_server.service
+sleep 5
+
+for i in {1..5}; do
+  # We want to loop here (5*5seconds) until the server is running and listening on its port
+  systemctl is-active --quiet birdnet_server.service \
+	  && grep 5050 <(netstat -tulpn 2>&1) \
+	  && logger "[$0] birdnet_server.service is running" \
+	  && break
+
+  sleep 5
 done
+
+# Let's check a final time to ensure the server is running
+systemctl is-active --quiet birdnet_server.service && grep 5050 <(netstat -tulpn 2>&1)
+status=$?
+
+if (( status != 0 )); then
+  logger "[$0] Unable to start birdnet_server.service... Looping until it start properly"
+
+  until grep 5050 <(netstat -tulpn 2>&1);do
+    sudo systemctl restart birdnet_server.service
+    sleep 45
+  done
+fi
+
+# Finally start the birdnet_analysis.service
 sudo systemctl restart birdnet_analysis.service

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -30,6 +30,8 @@ FORMAT = 'utf-8'
 DISCONNECT_MESSAGE = "!DISCONNECT"
 
 server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
 try:
     server.bind(ADDR)
 except BaseException:

--- a/scripts/update_birdnet_snippets.sh
+++ b/scripts/update_birdnet_snippets.sh
@@ -72,3 +72,5 @@ then
     -d $HOME/BirdNET-Pi/model
   mv $HOME/BirdNET-Pi/model/labels_en.txt $HOME/BirdNET-Pi/model/labels.txt
 fi
+
+sudo systemctl daemon-reload


### PR DESCRIPTION
I was attempting to make some changes to the way we selected languages, but realized that `Update Settings` and the subsequent `restart_services.sh` call were suuuuuuper slow.  Occasionally it'd give me a gateway timeout, but sometimes it'd randomly be a bit faster and not timeout.

This PR addresses that slowness and inconsistency.

I believe the problem was that depending on the socket use at the time of the `server.py` stopping+starting, it'd have issues binding and would get into this funky state where `systemctl` would say it's `active` but the `grep 5050 <(netstat -tulpn 2>&1)` would not return the bound port so `restart_services.sh` would just loop waiting `45` seconds between each restart until it'd get a successful startup.


### This PR does 2 things:

1. Adds the `SO_REUSEADDR` `sockopt` to `server.py` which python docs say
> Note
On POSIX platforms the SO_REUSEADDR socket option is set in order to immediately reuse previous sockets which were bound on the same address and remained in TIME_WAIT state. 

This seems to make `server.py` stop/restart/starts a lot more consistent

2. Refactors `restart_services.sh` in order to more quickly stop/restart/start services and ensure up and running.  If, for some reason, `birdnet_server.service` fails to start up cleanly it will "revert" back to using the old method of issuing a `restart` every 45 seconds until it binds the port `5050`.


From my testing experience so far this runs consistently in under 10 seconds and everything starts up cleanly and it's been working well