### PR TITLE
reduce excessive ffmpeg logging

### DIFF
--- a/scripts/livestream.sh
+++ b/scripts/livestream.sh
@@ -5,11 +5,11 @@ source /etc/birdnet/birdnet.conf
 if [ -z ${REC_CARD} ];then
   echo "Stream not supported"
 elif [[ ! -z ${RTSP_STREAM} ]];then
-  ffmpeg -loglevel 52 -ac ${CHANNELS} -i ${RTSP_STREAM} -acodec libmp3lame \
+  ffmpeg -loglevel 32 -ac ${CHANNELS} -i ${RTSP_STREAM} -acodec libmp3lame \
     -b:a 320k -ac ${CHANNELS} -content_type 'audio/mpeg' \
     -f mp3 icecast://source:${ICE_PWD}@localhost:8000/stream -re
 else
-	ffmpeg -loglevel 52 -ac ${CHANNELS} -f alsa -i ${REC_CARD} -acodec libmp3lame \
+	ffmpeg -loglevel 32 -ac ${CHANNELS} -f alsa -i ${REC_CARD} -acodec libmp3lame \
     -b:a 320k -ac ${CHANNELS} -content_type 'audio/mpeg' \
     -f mp3 icecast://source:${ICE_PWD}@localhost:8000/stream -re
 fi


### PR DESCRIPTION
In livestream.sh logging is set to 52 which seems excessive
a value of 32 (the default):
     'Show informative messages during processing. This is in addition to warnings and errors.'
would seem to be more appropriate.