### PR TITLE
disable tracking

### DIFF
--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -274,7 +274,7 @@ Restart=on-failure
 RestartSec=5
 Type=simple
 User=${USER}
-ExecStart=$HOME/BirdNET-Pi/birdnet/bin/streamlit run $HOME/BirdNET-Pi/scripts/plotly_streamlit.py --server.address localhost --server.baseUrlPath "/stats"
+ExecStart=$HOME/BirdNET-Pi/birdnet/bin/streamlit run $HOME/BirdNET-Pi/scripts/plotly_streamlit.py --browser.gatherUsageStats false --server.address localhost --server.baseUrlPath "/stats"
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/update_birdnet_snippets.sh
+++ b/scripts/update_birdnet_snippets.sh
@@ -102,6 +102,11 @@ if ! grep SILENCE_UPDATE_INDICATOR /etc/birdnet/birdnet.conf &>/dev/null;then
   sudo -u$USER echo "SILENCE_UPDATE_INDICATOR=0" >> /etc/birdnet/birdnet.conf
 fi
 
+if ! grep '--browser.gatherUsageStats false' $HOME/BirdNET-Pi/templates/birdnet_stats.service &>/dev/null ;then
+  sudo -E sed -i "s|ExecStart=.*|ExecStart=$HOME/BirdNET-Pi/birdnet/bin/streamlit run $HOME/BirdNET-Pi/scripts/plotly_streamlit.py --browser.gatherUsageStats false --server.address localhost --server.baseUrlPath \"/stats\"|" $HOME/BirdNET-Pi/templates/birdnet_stats.service
+  sudo systemctl daemon-reload && restart_services.sh
+fi
+
 
 sudo systemctl daemon-reload
 restart_services.sh


### PR DESCRIPTION
I came across this in my console while trying to access Species Stats (Streamlit):
![KLVz7qnSXL](https://user-images.githubusercontent.com/103586016/177162889-fb3626fd-a69c-4822-b412-db0aefce7158.png)

It seems that Streamlit collects telemetry data by default. An issue was raised in their GitHub repo (https://github.com/streamlit/streamlit/issues/4747), which details how it's illegal to collect data (even just the IP address) in Europe without explicit consent due to GDPR laws. The Streamlit founder then replied basically saying the onus is on the developers implementing Streamlit to deal with this themselves.

So I propose we disable sending data entirely, this PR does that.