### PR TITLE
Fix chown command in install scripts to use the user's primary group

### DIFF
--- a/scripts/clear_all_data.sh
+++ b/scripts/clear_all_data.sh
@@ -50,6 +50,6 @@ echo "Re-generating BirdDB.txt"
 touch $(dirname ${my_dir})/BirdDB.txt
 echo "Date;Time;Sci_Name;Com_Name;Confidence;Lat;Lon;Cutoff;Week;Sens;Overlap" > $(dirname ${my_dir})/BirdDB.txt
 ln -sf $(dirname ${my_dir})/BirdDB.txt ${my_dir}/BirdDB.txt
-chown $USER:$USER ${my_dir}/BirdDB.txt && chmod g+rw ${my_dir}/BirdDB.txt
+chown $USER:$(id -g) ${my_dir}/BirdDB.txt && chmod g+rw ${my_dir}/BirdDB.txt
 echo "Restarting services"
 restart_services.sh

--- a/scripts/createdb.sh
+++ b/scripts/createdb.sh
@@ -16,5 +16,5 @@ CREATE TABLE IF NOT EXISTS detections (
   Overlap FLOAT,
   File_Name VARCHAR(100) NOT NULL);
 EOF
-chown $USER:$USER $HOME/BirdNET-Pi/scripts/birds.db
+chown $USER:$(id -g) $HOME/BirdNET-Pi/scripts/birds.db
 chmod g+w $HOME/BirdNET-Pi/scripts/birds.db

--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -129,7 +129,7 @@ generate_BirdDB() {
   elif ! grep Date $my_dir/BirdDB.txt;then
     sudo -u ${USER} sed -i '1 i\Date;Time;Sci_Name;Com_Name;Confidence;Lat;Lon;Cutoff;Week;Sens;Overlap' $my_dir/BirdDB.txt
   fi
-  chown $USER:$USER ${my_dir}/BirdDB.txt && chmod g+rw ${my_dir}/BirdDB.txt
+  chown $USER:$(id -g) ${my_dir}/BirdDB.txt && chmod g+rw ${my_dir}/BirdDB.txt
 }
 
 set_login() {
@@ -414,7 +414,7 @@ install_weekly_cron() {
 }
 
 chown_things() {
-  chown -R $USER:$USER $HOME/Bird*
+  chown -R $USER:$(id -g) $HOME/Bird*
 }
 
 install_services() {

--- a/scripts/update_birdnet_snippets.sh
+++ b/scripts/update_birdnet_snippets.sh
@@ -7,7 +7,7 @@ HOME=$(awk -F: '/1000/ {print $6}' /etc/passwd)
 my_dir=$HOME/BirdNET-Pi/scripts
 
 # Sets proper permissions and ownership
-sudo -E chown -R $USER:$USER $HOME/*
+sudo -E chown -R $USER:$(id -g) $HOME/*
 sudo chmod -R g+wr $HOME/*
 
 if ! grep PRIVACY_THRESHOLD /etc/birdnet/birdnet.conf &>/dev/null;then


### PR DESCRIPTION
This fixes errors where the user's group is named differently from the user.
On my most recent Pi installation, my user's group was still `pi` even though my username was different.