### PR TITLE
Clone shallow on installation

### DIFF
--- a/newinstaller.sh
+++ b/newinstaller.sh
@@ -24,7 +24,7 @@ if [[ ! -z $PACKAGES_MISSING ]] ; then
 fi
 
 branch=main
-git clone -b $branch https://github.com/mcguirepr89/BirdNET-Pi.git ${HOME}/BirdNET-Pi &&
+git clone -b $branch --depth=1 https://github.com/mcguirepr89/BirdNET-Pi.git ${HOME}/BirdNET-Pi &&
 
 $HOME/BirdNET-Pi/scripts/install_birdnet.sh
 if [ ${PIPESTATUS[0]} -eq 0 ];then


### PR DESCRIPTION
Just clone a single commit, which will be faster and save space/bandwidth.