### PR TITLE
Convert /etc/crontab entries to systemd.timers

### DIFF
--- a/scripts/disk_check.sh
+++ b/scripts/disk_check.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -x
-used="$(df -h / | tail -n1 | awk '{print $5}')"
+source /etc/birdnet/birdnet.conf
+used="$(df -h $RECS_DIR | tail -n1 | awk '{print $5}')"
 
 if [ "${used//%}" -ge 95 ]; then
-  source /etc/birdnet/birdnet.conf
 
   case $FULL_DISK in
     purge) echo "Removing oldest data"

--- a/scripts/weekly_report.sh
+++ b/scripts/weekly_report.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 source /etc/birdnet/birdnet.conf
-if [ ${APPRISE_WEEKLY_REPORT} == 1 ];then
-	NOTIFICATION=$(curl 'localhost/views.php?view=Weekly%20Report&ascii=true')
-	NOTIFICATION=${NOTIFICATION#*#}
+if [ ${APPRISE_WEEKLY_REPORT} == "1" ];then
+	NOTIFICATION=$(curl --silent 'localhost/views.php?view=Weekly%20Report&ascii=true')
+	[ -z "$NOTIFICATION" ] && echo "Nothing to send in weekly report" && exit
 	firstLine=`echo "${NOTIFICATION}" | head -1`
 	NOTIFICATION=`echo "${NOTIFICATION}" | tail -n +2`
 	$HOME/BirdNET-Pi/birdnet/bin/apprise -vv -t "${firstLine}" -b "${NOTIFICATION}" --input-format=html --config=$HOME/BirdNET-Pi/apprise.txt

--- a/templates/cleanup.cron
+++ b/templates/cleanup.cron
@@ -1,6 +1,0 @@
-#birdnet
-*/5 * * * * $USER /usr/local/bin/disk_check.sh >/dev/null 2>&1
-#birdnet
-*/3 * * * * $USER /usr/local/bin/cleanup.sh >/dev/null 2>&1
-#birdnet
-@reboot $USER /usr/local/bin/cleanup.sh >/dev/null 2>&1

--- a/templates/weekly_report.cron
+++ b/templates/weekly_report.cron
@@ -1,2 +1,0 @@
-#birdnet
-0 1 * * 1 $USER /usr/local/bin/weekly_report.sh >/dev/null 2>&1


### PR DESCRIPTION
After reinstalling a few times, I noticed the cleanup and weekly_report entries kept getting appended to /etc/crontab. Instead this solution creates a systemd timer and service for those entries in install_services.sh.