### PR TITLE
Remove duplicate "No Detections For Today" message

### DIFF
--- a/scripts/overview.php
+++ b/scripts/overview.php
@@ -264,9 +264,7 @@ $refresh = $config['RECORDING_LENGTH'];
 $time = time();
 if (file_exists('./Charts/'.$chart)) {
   echo "<img id='chart' src=\"/Charts/$chart?nocache=$time\">";
-} else {
-  echo "<p>No Detections For Today</p>";
-}
+} 
 ?>
 </div>
 


### PR DESCRIPTION
Something that should be rarely seen, a duplicate "No Detections For Today" message.
Change removes the duplicate left-aligned message and leaves centered message.