### PR TITLE
Update update_caddyfile.sh

### DIFF
--- a/scripts/update_caddyfile.sh
+++ b/scripts/update_caddyfile.sh
@@ -7,7 +7,7 @@ if [ -f /etc/caddy/Caddyfile ];then
   cp /etc/caddy/Caddyfile{,.original}
 fi
 if ! [ -z ${CADDY_PWD} ];then
-HASHWORD=$(caddy hash-password -plaintext ${CADDY_PWD})
+HASHWORD=$(caddy hash-password --plaintext ${CADDY_PWD})
 cat << EOF > /etc/caddy/Caddyfile
 http:// ${BIRDNETPI_URL} {
   root * ${EXTRACTED}


### PR DESCRIPTION
Updated call to caddy's hash-password to resolve error with using only a single dash before plaintext. https://caddyserver.com/docs/command-line#caddy-hash-password