### PR TITLE
add addtional except to handle sqlite errors

### DIFF
--- a/scripts/server.py
+++ b/scripts/server.py
@@ -398,6 +398,9 @@ def handle_client(conn, addr):
                                         con.commit()
                                         con.close()
                                         break
+                                    except sqlite3.Error as er:
+                                        print('SQLite error: %s' % (' '.join(er.args)))
+                                        print("Exception class is: ", er.__class__)
                                     except BaseException:
                                         print("Database busy")
                                         time.sleep(2)


### PR DESCRIPTION
Had some issues when I was switching back and forth between the verification branch and main, and couldn't pin down the issue, apart from the database busy error. Of course it was due to the tables being different, but I couldn't track that down with the current except statement
This will provide some additional context if there is an issue trying to run the database query.

The additional logging provides details like this:

```
Nov 01 00:40:12 birdnet-pi python3[27629]: SQLite error: table detections has 14 columns but 12 values were supplied
Nov 01 00:40:12 birdnet-pi python3[27629]: Exception class is:  <class 'sqlite3.OperationalError'>
Nov 01 00:40:12 birdnet-pi python3[27629]: SQLite error: table detections has 14 columns but 12 values were supplied
Nov 01 00:40:12 birdnet-pi python3[27629]: Exception class is:  <class 'sqlite3.OperationalError'>
Nov 01 00:40:12 birdnet-pi python3[27629]: SQLite error: table detections has 14 columns but 12 values were supplied
Nov 01 00:40:12 birdnet-pi python3[27629]: Exception class is:  <class 'sqlite3.OperationalError'>
```