### PR TITLE
ffmpeg: disable stdin interaction

### DIFF
--- a/scripts/birdnet_recording.sh
+++ b/scripts/birdnet_recording.sh
@@ -8,7 +8,7 @@ if [ ! -z $RTSP_STREAM ];then
   [ -d $RECS_DIR/StreamData ] || mkdir -p $RECS_DIR/StreamData
   while true;do
     for i in ${RTSP_STREAM//,/ };do
-      ffmpeg -i  ${i} -t ${RECORDING_LENGTH} -vn -acodec pcm_s16le -ac 2 -ar 48000 file:${RECS_DIR}/StreamData/$(date "+%F")-birdnet-$(date "+%H:%M:%S").wav
+      ffmpeg -nostdin -i  ${i} -t ${RECORDING_LENGTH} -vn -acodec pcm_s16le -ac 2 -ar 48000 file:${RECS_DIR}/StreamData/$(date "+%F")-birdnet-$(date "+%H:%M:%S").wav
     done
   done
 else

--- a/scripts/livestream.sh
+++ b/scripts/livestream.sh
@@ -5,11 +5,11 @@ source /etc/birdnet/birdnet.conf
 if [ -z ${REC_CARD} ];then
   echo "Stream not supported"
 elif [[ ! -z ${RTSP_STREAM} ]];then
-  ffmpeg -loglevel 32 -ac ${CHANNELS} -i ${RTSP_STREAM} -acodec libmp3lame \
+  ffmpeg -nostdin -loglevel 32 -ac ${CHANNELS} -i ${RTSP_STREAM} -acodec libmp3lame \
     -b:a 320k -ac ${CHANNELS} -content_type 'audio/mpeg' \
     -f mp3 icecast://source:${ICE_PWD}@localhost:8000/stream -re
 else
-	ffmpeg -loglevel 32 -ac ${CHANNELS} -f alsa -i ${REC_CARD} -acodec libmp3lame \
+	ffmpeg -nostdin -loglevel 32 -ac ${CHANNELS} -f alsa -i ${REC_CARD} -acodec libmp3lame \
     -b:a 320k -ac ${CHANNELS} -content_type 'audio/mpeg' \
     -f mp3 icecast://source:${ICE_PWD}@localhost:8000/stream -re
 fi


### PR DESCRIPTION
`ffmpeg` enables interaction on stdin by default ([see `-stdin`](https://ffmpeg.org/ffmpeg.html#toc-Main-options)), which may have [undesirable consequences](https://superuser.com/questions/1492507/why-does-ffmpeg-require-nostdin-in-while-loop) when running it in the background, as BirdNET-Pi does by running `livestream.sh` and `birdnet_recording.sh` scripts as services. this PR adds the `-nostdin` option to `ffmpeg` calls in such scripts to disable interaction via the stdin stream.

this change does not break current usage in any way and it may fix the issue #579. I say *may* because I've since been unable to replicate that issue. of note, the author of #579 closed it mentioning a solution--`ffmpeg ... < /dev/null`--that is equivalent to (but less flexible than) the change introduced here--`ffmpeg -nostdin ...`.