### PR TITLE
load apprise notification plugins from standard locations

### DIFF
--- a/scripts/config.php
+++ b/scripts/config.php
@@ -263,7 +263,7 @@ if(isset($_GET['sendtest']) && $_GET['sendtest'] == "true") {
   $body = str_replace("\$overlap", $overlap, $body);
   $body = str_replace("\$flickrimage", $exampleimage, $body);
 
-  echo "<pre class=\"bash\">".shell_exec($home."/BirdNET-Pi/birdnet/bin/apprise -vv -t '".$title."' -b '".$body."' ".$attach." ".$cf." ")."</pre>";
+  echo "<pre class=\"bash\">".shell_exec($home."/BirdNET-Pi/birdnet/bin/apprise -vv --plugin-path ".$home."/.apprise/plugins "." -t '".$title."' -b '".$body."' ".$attach." ".$cf." ")."</pre>";
 
   die();
 }

--- a/scripts/utils/notifications.py
+++ b/scripts/utils/notifications.py
@@ -13,7 +13,13 @@ DB_PATH = userDir + '/BirdNET-Pi/scripts/birds.db'
 flickr_images = {}
 species_last_notified = {}
 
-apobj = apprise.Apprise()
+asset = apprise.AppriseAsset(
+    plugin_paths=[
+        userDir + "/.apprise/plugins",
+        userDir + "/.config/apprise/plugins",
+    ]
+)
+apobj = apprise.Apprise(asset=asset)
 config = apprise.AppriseConfig()
 config.add(APPRISE_CONFIG)
 apobj.add(config)


### PR DESCRIPTION
Hi!

Thanks for making BirdNET-Pi. These changes adjust the apprise integration so that any custom apprise plugins that are placed in the standard locations are loaded. If no plugins exist in those locations, nothing changes.

For an example of how we have been using this functionality, you can see a custom apprise plugin at https://gist.github.com/statik/db1944c31f29262be900236c2a9986ff that I developed with @knmurphy to send custom lower thirds to a livestream graphics system.

