### PR TITLE
streamlit st.cache deprecated - use st.cache_data st.cache_resource

### DIFF
--- a/scripts/plotly_streamlit.py
+++ b/scripts/plotly_streamlit.py
@@ -38,8 +38,7 @@ st.markdown("""
         """, unsafe_allow_html=True)
 
 
-@st.cache(hash_funcs={Connection: id})
-# @st.cache(allow_output_mutation=True)
+@st.cache_resource()
 def get_connection(path: str):
     return sqlite3.connect(path, check_same_thread=False)
 
@@ -89,7 +88,7 @@ else:
 # end_date = datetime(2022 ,5 ,17).date()
 
 
-@st.cache()
+@st.cache_data()
 def date_filter(df, start_date, end_date):
     filt = (df2.index >= pd.Timestamp(start_date)) & (df2.index <= pd.Timestamp(end_date + timedelta(days=1)))
     df = df[filt]
@@ -132,7 +131,7 @@ else:
     resample_time = resample_times[resample_sel]
 
 
-@st.cache()
+@st.cache_data()
 def time_resample(df, resample_time):
     if resample_time == 'Raw':
         df_resample = df['Com_Name']


### PR DESCRIPTION
Since streamlit 1.18.0 (Feb 14th 2023) st.cache has been deprecated: the functionality exists in two new forms st.cache_data and st.cache_resource. Use of st.cache produces a deprecation warning

Please check this change before merging - I am not an expert in streamlit