### PR TITLE
Fix de-sync between models and labels

### DIFF
--- a/scripts/config.php
+++ b/scripts/config.php
@@ -107,20 +107,8 @@ if(isset($_GET["latitude"])){
   } elseif (file_exists('./scripts/firstrun.ini')) {
     $lang_config = parse_ini_file('./scripts/firstrun.ini');
   }
-  if ($language != $lang_config['DATABASE_LANG']){
-    $user = trim(shell_exec("awk -F: '/1000/{print $1}' /etc/passwd"));
-    $home = trim(shell_exec("awk -F: '/1000/{print $6}' /etc/passwd"));
 
-    // Archive old language file
-    syslog_shell_exec("cp -f $home/BirdNET-Pi/model/labels.txt $home/BirdNET-Pi/model/labels.txt.old", $user);
-
-    // Install new language label file
-    syslog_shell_exec("$home/BirdNET-Pi/scripts/install_language_label.sh -l $language", $user);
-
-    syslog(LOG_INFO, "Successfully changed language to '$language'");
-  }
-
-  if ($model != $lang_config['MODEL']){
+  if ($model != $lang_config['MODEL'] || $language != $lang_config['DATABASE_LANG']){
     $user = trim(shell_exec("awk -F: '/1000/{print $1}' /etc/passwd"));
     $home = trim(shell_exec("awk -F: '/1000/{print $6}' /etc/passwd"));
 
@@ -134,7 +122,7 @@ if(isset($_GET["latitude"])){
       syslog_shell_exec("$home/BirdNET-Pi/scripts/install_language_label.sh -l $language", $user);
     }
 
-    syslog(LOG_INFO, "Successfully changed language to '$language'");
+    syslog(LOG_INFO, "Successfully changed language to '$language' and model to '$model'");
   }
 
 


### PR DESCRIPTION
The `model/labels.txt` file could get out of sync with the model being used for classification when changing language in Settings. As a result, the resulting classifications will usually make no sense for the specified location. 

To reproduce the issue:

- Configure the server to use the BirdNET-Analyzer model.
  - The model and labels should be in sync at this point.
- Configure the server app to use a different language.
  - The `labels.txt` file will be updated to the BirdNET-Lite labels, whereas the model is still set to Analyzer.

As a workaround, you can manually run `install_language_label_nm.sh`; or alternatively, in the UI, change the model back to BirdNET-Lite and then re-change it back to BirdNET-Analyzer while simultaneously changing the language.

The root cause was that a change of language always assumed it would be set to the BirdNET-lite model, by calling `install_language_label.sh`, rather than looking at the model and calling the correct script.

This PR fixes this issue by treating model and language changes similarly: we should always update with the appropriate script when either the model or language is changed.