### PR TITLE
Created try/except statement around reading the audio data 

### DIFF
--- a/scripts/server.py
+++ b/scripts/server.py
@@ -395,8 +395,16 @@ def handle_client(conn, addr):
 
                 birdweather_id = args.birdweather_id
 
-                # Read audio data
-                audioData = readAudioData(args.i, args.overlap)
+                # Read audio data & handle errors
+                try:
+                    audioData = readAudioData(args.i, args.overlap)
+
+                except (NameError, TypeError) as e:
+                    print(f"Error with the following info: {e}")
+                    open('~/BirdNET-Pi/analyzing_now.txt', 'w').close()
+
+                finally:
+                    pass
 
                 # Get Date/Time from filename in case Pi gets behind
                 # now = datetime.now()
@@ -560,7 +568,7 @@ def handle_client(conn, addr):
                                             post_algorithm = "\"algorithm\": " + "\"2p2\"" + ","
                                         else:
                                             post_algorithm = "\"algorithm\": " + "\"alpha\"" + ","
-                                            
+
                                         post_confidence = "\"confidence\": " + str(entry[1])
                                         post_end = " }"
 


### PR DESCRIPTION
Full Commit Message: `Created try/except statement around reading the audio data from the recordings. See the issue linked in the PR. By clearing the text in analyzing_now, my system moves past the error-causing file and continues processing.`

A fix for issue #798 . I was able to replicate the issue this evening and spent some time trying to implement a fix. 

I tried a bunch of `try/except` statements that would just move past the error and not crash the other services but nothing seemed to work. The same errors persisted. As I was looking through the logs (see below), I then realized that the `birdnet_analysis.sh` script continued adding files to the array of loaded files, but it was the first file in that array that was causing the other services to crash. 

After adding `line 404` which clears out the `analyzing_now.txt` file, all services started working again as expected. Here's a screenshot of the log.

Let me know if you want this implemented in a different way. 
 
<img width="1317" alt="Screenshot 2023-04-03 at 9 57 23 PM" src="https://user-images.githubusercontent.com/44226464/229668475-8ec9456b-ff66-41c3-8f68-e05f4be165aa.png">
