### PR TITLE
Update server.py

### DIFF
--- a/scripts/server.py
+++ b/scripts/server.py
@@ -12,6 +12,7 @@ import operator
 import socket
 import threading
 import os
+import gzip
 
 from utils.notifications import sendAppriseNotifications
 from utils.parse_settings import config_to_settings
@@ -534,7 +535,9 @@ def handle_client(conn, addr):
 
                                             with open(args.i, 'rb') as f:
                                                 wav_data = f.read()
-                                            response = requests.post(url=soundscape_url, data=wav_data, headers={'Content-Type': 'application/octet-stream'})
+                                            gzip_wav_data = gzip.compress(wav_data)
+                                            response = requests.post(url=soundscape_url, data=gzip_wav_data, headers={'Content-Type': 'application/octet-stream',
+                                                                                                                      'Content-Encoding': 'gzip'})
                                             print("Soundscape POST Response Status - ", response.status_code)
                                             sdata = response.json()
                                             soundscape_id = sdata['soundscape']['id']


### PR DESCRIPTION
Tim Clark (tim@birdweather.com) has recently enabled gzip support on BirdWeather to make receiving gzip'ped wav sound files possible.

I have verified that the patch works. It reduces the  size of the .wav sound file from 2880044 to ~780000 bytes so it will save a lot of bandwidth.