### PR TITLE
Make ffmpeg record the first audio stream for RTSP

### DIFF
--- a/scripts/birdnet_recording.sh
+++ b/scripts/birdnet_recording.sh
@@ -29,7 +29,7 @@ if [ ! -z $RTSP_STREAM ];then
       # Map id used to map input to output, this is 0 based in ffmpeg decrement
       MAP_ID=$((RTSP_STREAMS_STARTED_COUNT-1))
       # Build up the parameters to process the RSTP stream, including mapping for the output
-      FFMPEG_PARAMS+="-vn -thread_queue_size 512 -i ${i} -map ${MAP_ID} -t ${RECORDING_LENGTH} -acodec pcm_s16le -ac 2 -ar 48000 file:${RECS_DIR}/StreamData/$(date "+%F")-birdnet-RTSP_${RTSP_STREAMS_STARTED_COUNT}-$(date "+%H:%M:%S").wav "
+      FFMPEG_PARAMS+="-vn -thread_queue_size 512 -i ${i} -map ${MAP_ID}:a:0 -t ${RECORDING_LENGTH} -acodec pcm_s16le -ac 2 -ar 48000 file:${RECS_DIR}/StreamData/$(date "+%F")-birdnet-RTSP_${RTSP_STREAMS_STARTED_COUNT}-$(date "+%H:%M:%S").wav "
       # Increment counter
       ((RTSP_STREAMS_STARTED_COUNT += 1))
     done


### PR DESCRIPTION
Small fix for now to handle of RTSP streams that may contain more than 1 audio stream within them, we just tell ffmpeg to use the first audio stream for the recording. 
By default ffmpeg will go to the first stream, but when there are more than one it tries to use both to output into the recording and this raises a error.

A future enhancement to this is to allow the user to to set what audio stream to use via the web ui setting page, just in case there is a scenario where the first one doesn't work for some reason. 

Resolves the issue with Ubiquity RTSP streams in Discussion #842 
This works for streams containing only 1  audio steam and also 2 audio streams as per #842 