### PR TITLE
Added clickable BirdNET-Pi version info in the SystemControls web page

### DIFF
--- a/scripts/system_controls.php
+++ b/scripts/system_controls.php
@@ -44,4 +44,12 @@ function update() {
   <form action="" method="GET">
     <button type="submit" name="submit" value="sudo clear_all_data.sh" onclick="return confirm('Clear ALL Data? Note that this cannot be undone and will take up to 90 seconds.')">Clear ALL data</button>
   </form> 
+<?php
+  $cmd="cat ".$home."/BirdNET-Pi/.git/refs/heads/main";
+  $curr_hash = shell_exec($cmd);
+?>
+  <p style="font-size:11px;text-align:center"></br></br>Running version: </p>
+  <a href="https://github.com/mcguirepr89/BirdNET-Pi/commit/<?php echo $curr_hash; ?>" target="_blank">
+    <p style="font-size:11px;text-align:center;box-sizing: border-box"><?php echo $curr_hash; ?></p>
+  </a>
 </div>


### PR DESCRIPTION
I think that there is a lack of information about what BirdNET-Pi is currently running on an installed system.
So I just added the current git hash, in the "System Controls" page, below the Upgrade button.
This information is clickable, which upon click, opens the latest github commit page.