### PR TITLE
Python - Create a file path and directory resolver & migrate away from hard coded paths

### DIFF
--- a/scripts/daily_plot.py
+++ b/scripts/daily_plot.py
@@ -1,5 +1,4 @@
 import sqlite3
-import os
 import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
@@ -8,9 +7,9 @@ from datetime import datetime
 import textwrap
 import matplotlib.font_manager as font_manager
 from matplotlib import rcParams
+import utils.common as common
 
-userDir = os.path.expanduser('~')
-conn = sqlite3.connect(userDir + '/BirdNET-Pi/scripts/birds.db')
+conn = sqlite3.connect(common.filepath_resolver.get_file_path('birds.db'))
 df = pd.read_sql_query("SELECT * from detections", conn)
 cursor = conn.cursor()
 cursor.execute('SELECT * FROM detections WHERE Date = DATE(\'now\', \'localtime\')')
@@ -31,7 +30,7 @@ df['Hour of Day'] = [r.hour for r in df.Time]
 df_plt = df  # Default to use the whole Dbase
 
 # Add every font at the specified location
-font_dir = [userDir + '/BirdNET-Pi/homepage/static']
+font_dir = [common.filepath_resolver.get_directory('web_fonts')]
 for font in font_manager.findSystemFonts(font_dir):
     font_manager.fontManager.addfont(font)
 
@@ -130,8 +129,7 @@ f.subplots_adjust(top=0.9)
 plt.suptitle("Top 10 Last Updated: " + str(now.strftime("%Y-%m-%d %H:%M")))
 
 # Save combined plot
-userDir = os.path.expanduser('~')
-savename = userDir + '/BirdSongs/Extracted/Charts/Combo-' + str(now.strftime("%Y-%m-%d")) + '.png'
+savename = common.filepath_resolver.get_directory('extracted_charts') + '/Combo-' + str(now.strftime("%Y-%m-%d")) + '.png'
 plt.savefig(savename)
 plt.show()
 plt.close()
@@ -210,7 +208,7 @@ f.subplots_adjust(top=0.9)
 plt.suptitle("Bottom 10 Last Updated: " + str(now.strftime("%Y-%m-%d %H:%M")))
 
 # Save combined plot
-savename = userDir + '/BirdSongs/Extracted/Charts/Combo2-' + str(now.strftime("%Y-%m-%d")) + '.png'
+savename = common.filepath_resolver.get_directory('extracted_charts') + '/Combo2-' + str(now.strftime("%Y-%m-%d")) + '.png'
 plt.savefig(savename)
 plt.show()
 plt.close()

--- a/scripts/plotly_streamlit.py
+++ b/scripts/plotly_streamlit.py
@@ -13,11 +13,11 @@ import plotly.express as px
 from sklearn.preprocessing import normalize
 from suntime import Sun
 from datetime import datetime
+import utils.common as common
 
 pio.templates.default = "plotly_white"
 
-userDir = os.path.expanduser('~')
-URI_SQLITE_DB = userDir + '/BirdNET-Pi/scripts/birds.db'
+URI_SQLITE_DB = common.filepath_resolver.get_file_path('birds.db')
 
 st.set_page_config(layout='wide')
 
@@ -373,8 +373,8 @@ if daily is False:
                     date_specie = df2.loc[df2['File_Name'] == recording, ['Date', 'Com_Name']]
                     date_dir = date_specie['Date'].values[0]
                     specie_dir = date_specie['Com_Name'].values[0].replace(" ", "_")
-                    st.image(userDir + '/BirdSongs/Extracted/By_Date/' + date_dir + '/' + specie_dir + '/' + recording + '.png')
-                    st.audio(userDir + '/BirdSongs/Extracted/By_Date/' + date_dir + '/' + specie_dir + '/' + recording)
+                    st.image(common.filepath_resolver.get_directory('extracted_by_date') + '/' + date_dir + '/' + specie_dir + '/' + recording + '.png')
+                    st.audio(common.filepath_resolver.get_directory('extracted_by_date') + '/' + date_dir + '/' + specie_dir + '/' + recording)
                 except Exception:
                     st.title('RECORDING NOT AVAILABLE :(')
             # try:
@@ -386,9 +386,8 @@ if daily is False:
             if seen:
                 with colc:
                     verified = st.radio("Verification", ['True Positive', 'False Positive'])
-
                     if verified == "False Positive":
-                        df_names = pd.read_csv(userDir + '/BirdNET-Pi/model/labels.txt', delimiter='_', names=['Sci_Name', 'Com_Name'])
+                        df_names = pd.read_csv(common.filepath_resolver.get_file_path('labels.txt'), delimiter='_', names=['Sci_Name', 'Com_Name'])
                         df_unknown = pd.DataFrame({"Sci_Name": ["UNKNOWN"], "Com_Name": ["UNKNOWN"]})
                         df_names = pd.concat([df_unknown, df_names], ignore_index=True)
                         with cold:

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -14,9 +14,9 @@ import socket
 import threading
 import os
 import gzip
+import utils.common as common
 
 from utils.notifications import sendAppriseNotifications
-from utils.parse_settings import config_to_settings
 
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 os.environ['CUDA_VISIBLE_DEVICES'] = ''
@@ -34,8 +34,7 @@ ADDR = (SERVER, PORT)
 FORMAT = 'utf-8'
 DISCONNECT_MESSAGE = "!DISCONNECT"
 
-userDir = os.path.expanduser('~')
-DB_PATH = userDir + '/BirdNET-Pi/scripts/birds.db'
+DB_PATH = common.filepath_resolver.get_file_path('birds.db')
 
 PREDICTED_SPECIES_LIST = []
 
@@ -50,7 +49,7 @@ except BaseException:
 
 
 # Open most recent Configuration and grab DB_PWD as a python variable
-with open(userDir + '/BirdNET-Pi/scripts/thisrun.txt', 'r') as f:
+with open(common.filepath_resolver.get_file_path('thisrun.txt'), 'r') as f:
     this_run = f.readlines()
     audiofmt = "." + str(str(str([i for i in this_run if i.startswith('AUDIOFMT')]).split('=')[1]).split('\\')[0])
     priv_thresh = float("." + str(str(str([i for i in this_run if i.startswith('PRIVACY_THRESHOLD')]).split('=')[1]).split('\\')[0])) / 10
@@ -72,7 +71,7 @@ def loadModel():
 
     # Load TFLite model and allocate tensors.
     # model will either be BirdNET_GLOBAL_3K_V2.3_Model_FP16 (new) or BirdNET_6K_GLOBAL_MODEL (old)
-    modelpath = userDir + '/BirdNET-Pi/model/'+model+'.tflite'
+    modelpath = common.filepath_resolver.get_directory('model') + '/'+model+'.tflite'
     myinterpreter = tflite.Interpreter(model_path=modelpath, num_threads=2)
     myinterpreter.allocate_tensors()
 
@@ -88,7 +87,7 @@ def loadModel():
 
     # Load labels
     CLASSES = []
-    labelspath = userDir + '/BirdNET-Pi/model/labels.txt'
+    labelspath = common.filepath_resolver.get_file_path('labels.txt')
     with open(labelspath, 'r') as lfile:
         for line in lfile.readlines():
             CLASSES.append(line.replace('\n', ''))
@@ -104,7 +103,7 @@ def loadMetaModel():
     global M_OUTPUT_LAYER_INDEX
 
     # Load TFLite model and allocate tensors.
-    M_INTERPRETER = tflite.Interpreter(model_path=userDir + '/BirdNET-Pi/model/BirdNET_GLOBAL_3K_V2.3_MData_Model_FP16.tflite')
+    M_INTERPRETER = tflite.Interpreter(model_path=common.filepath_resolver.get_directory('model') + '/BirdNET_GLOBAL_3K_V2.3_MData_Model_FP16.tflite')
     M_INTERPRETER.allocate_tensors()
 
     # Get input and output tensors.
@@ -259,7 +258,7 @@ def predict(sample, sensitivity):
 
     for i in range(min(10, len(p_sorted))):
         if p_sorted[i][0] == 'Human_Human':
-            with open(userDir + '/BirdNET-Pi/HUMAN.txt', 'a') as rfile:
+            with open(common.filepath_resolver.get_file_path('HUMAN.txt'), 'a') as rfile:
                 rfile.write(str(datetime.datetime.now()) + str(p_sorted[i]) + ' ' + str(human_cutoff) + '\n')
 
     return p_sorted[:human_cutoff]
@@ -462,8 +461,7 @@ def handle_client(conn, addr):
                 myReturn = ''
                 for i in detections:
                     myReturn += str(i) + '-' + str(detections[i][0]) + '\n'
-
-                with open(userDir + '/BirdNET-Pi/BirdDB.txt', 'a') as rfile:
+                with open(common.filepath_resolver.get_file_path('BirdDB.txt'), 'a') as rfile:
                     for d in detections:
                         species_apprised_this_run = []
                         for entry in detections[d]:
@@ -508,7 +506,7 @@ def handle_client(conn, addr):
 
                                 # Apprise of detection if not already alerted this run.
                                 if not entry[0] in species_apprised_this_run:
-                                    settings_dict = config_to_settings(userDir + '/BirdNET-Pi/scripts/thisrun.txt')
+                                    settings_dict = common.parse_settings.config_to_settings(common.filepath_resolver.get_file_path('thisrun.txt'))
                                     sendAppriseNotifications(species,
                                                              str(score),
                                                              File_Name,

--- a/scripts/species.py
+++ b/scripts/species.py
@@ -15,6 +15,7 @@ import os
 import sys
 import argparse
 import datetime
+import utils.common as common
 
 try:
     import tflite_runtime.interpreter as tflite
@@ -31,7 +32,7 @@ def loadMetaModel():
     global CLASSES
 
     # Load TFLite model and allocate tensors.
-    M_INTERPRETER = tflite.Interpreter(model_path=userDir + '/BirdNET-Pi/model/BirdNET_GLOBAL_3K_V2.3_MData_Model_FP16.tflite')
+    M_INTERPRETER = tflite.Interpreter(model_path=common.filepath_resolver.get_directory('model') + '/BirdNET_GLOBAL_3K_V2.3_MData_Model_FP16.tflite')
     M_INTERPRETER.allocate_tensors()
 
     # Get input and output tensors.
@@ -44,7 +45,7 @@ def loadMetaModel():
 
     # Load labels
     CLASSES = []
-    labelspath = userDir + '/BirdNET-Pi/model/labels.txt'
+    labelspath = common.filepath_resolver.get_file_path('labels.txt')
     with open(labelspath, 'r') as lfile:
         for line in lfile.readlines():
             CLASSES.append(line.replace('\n', ''))
@@ -103,9 +104,8 @@ def getSpeciesList(lat, lon, week, threshold=0.05, sort=False):
     return slist
 
 
-userDir = os.path.expanduser('~')
-DB_PATH = userDir + '/BirdNET-Pi/scripts/birds.db'
-with open(userDir + '/BirdNET-Pi/scripts/thisrun.txt', 'r') as f:
+DB_PATH = common.filepath_resolver.get_file_path('birds.db')
+with open(common.filepath_resolver.get_file_path('thisrun.txt'), 'r') as f:
 
     this_run = f.readlines()
     lat = str(str(str([i for i in this_run if i.startswith('LATITUDE')]).split('=')[1]).split('\\')[0])

--- a/scripts/utils/common.py
+++ b/scripts/utils/common.py
@@ -1,0 +1,42 @@
+from . import parse_settings
+from . import filepath_resolver
+from . import notifications
+
+# Configuration settings
+CONFIG = {}
+
+# Path Variables
+BIRDNET_CONF_PATH = filepath_resolver.get_file_path('birdnet.conf')
+APPRISE_CONFIG = filepath_resolver.get_file_path('apprise.txt')
+DB_PATH = filepath_resolver.get_file_path('birds.db')
+# NOT CURRENTLY USED
+ALPHA_MODEL_6K = 'BirdNET_6K_GLOBAL_MODEL'
+META_MODEL_3K = 'BirdNET_GLOBAL_3K_V2.3_MData_Model_FP16'
+
+
+def update_module_vars():
+    filepath_resolver.CONFIG = CONFIG
+    #
+    notifications.userDir = filepath_resolver.get_directory('home')
+    notifications.DB_PATH = DB_PATH
+    notifications.APPRISE_CONFIG = APPRISE_CONFIG
+
+
+def parse_config():
+    # Loads setting/config
+    global CONFIG
+    CONFIG = parse_settings.config_to_settings(filepath_resolver.get_file_path('thisrun.txt'))
+    update_module_vars()
+
+
+def get_setting(setting_name):
+    # Retrieves the specified setting from the config
+    parse_config()
+
+    if CONFIG.get(setting_name) is not None:
+        return CONFIG.get(setting_name)
+    else:
+        return None
+
+
+parse_config()

--- a/scripts/utils/filepath_resolver.py
+++ b/scripts/utils/filepath_resolver.py
@@ -1,0 +1,155 @@
+import os
+
+CONFIG = {}
+userDir = os.path.expanduser('~')
+
+
+def get_directory(directory_name):
+    # Directory Path Helper, returns a full directory path for a supplied directory name e+g home, processed, extracted
+
+    directory_name = directory_name.lower()
+
+    if directory_name == "home":
+        return userDir
+    ##
+    elif directory_name == "birdnet-pi" or directory_name == "birdnet_pi":
+        return get_directory('home') + '/BirdNET-Pi'
+    ##
+    elif directory_name == "recs_dir" or directory_name == "recordings_dir":
+        recs_directory_name_setting = CONFIG.get('RECS_DIR')
+        return recs_directory_name_setting.replace('$HOME', get_directory('home'))
+    ##
+    elif directory_name == "processed":
+        processed_directory_name_setting = CONFIG.get('PROCESSED')
+        return get_directory('recs_dir') + processed_directory_name_setting.replace('${RECS_DIR}', '')
+    ##
+    elif directory_name == "extracted":
+        extracted_directory_name_setting = CONFIG.get('EXTRACTED')
+        return get_directory('recs_dir') + extracted_directory_name_setting.replace('${RECS_DIR}', '')
+    ##
+    elif directory_name == "extracted_bydate" or directory_name == "extracted_by_date":
+        return get_directory('extracted') + '/By_Date'
+    ##
+    elif directory_name == "extracted_charts":
+        return get_directory('extracted') + '/Charts'
+    ##
+    elif directory_name == "shifted_audio" or directory_name == "shifted_directory_name":
+        return get_directory('home') + '/BirdSongs/Extracted/By_Date/shifted'
+    ##
+    elif directory_name == "database":
+        ## NOT CURRENTLY USED
+        return get_directory('birdnet_pi') + '/database'
+    ##
+    elif directory_name == "config":
+        ## NOT CURRENTLY USED
+        return get_directory('birdnet_pi') + '/config'
+    ##
+    elif directory_name == "models" or directory_name == "model":
+        return get_directory('birdnet_pi') + '/model'
+    ##
+    elif directory_name == "python3_ve":
+        return get_directory('birdnet_pi') + '/birdnet/bin'
+    ##
+    elif directory_name == "scripts":
+        return get_directory('birdnet_pi') + '/scripts'
+    ##
+    elif directory_name == "stream_data":
+        return get_directory('recs_dir') + '/StreamData'
+    ##
+    elif directory_name == "templates":
+        return get_directory('birdnet_pi') + '/templates'
+    ##
+    elif directory_name == "web" or directory_name == "www":
+        return get_directory('birdnet_pi') + '/homepage'
+    ##
+    elif directory_name == "web_fonts" or directory_name == "www_fonts":
+        return get_directory('www') + '/static'
+    ##
+
+    return ""
+
+
+def get_file_path(filename):
+    # Returns the full filepath for the specified filename
+
+    if filename == "analyzing_now.txt":
+        return get_directory('birdnet_pi') + "/analyzing_now.txt"
+    ##
+    elif filename == "apprise.txt":
+        return get_directory('birdnet_pi') + "/apprise.txt"
+    ##
+    elif filename == "birdnet.conf":
+        return get_directory('birdnet_pi') + "/birdnet.conf"
+    ##
+    elif filename == "etc_birdnet.conf":
+        return "/etc/birdnet/birdnet.conf"
+    ##
+    elif filename == "BirdDB.txt":
+        return get_directory('birdnet_pi') + "/BirdDB.txt"
+    ##
+    elif filename == "birds.db":
+        return get_directory('scripts') + "/birds.db"
+    ##
+    elif filename == "blacklisted_images.txt":
+        return get_directory('scripts') + "/blacklisted_images.txt"
+    ##
+    elif filename == "disk_check_exclude.txt":
+        return get_directory('scripts') + "/disk_check_exclude.txt"
+    ##
+    elif filename == "email_template":
+        return get_directory('scripts') + "/email_template"
+    ##
+    elif filename == "email_template2":
+        return get_directory('scripts') + "/email_template2"
+    ##
+    elif filename == "exclude_species_list.txt":
+        return get_directory('scripts') + "/exclude_species_list.txt"
+    ##
+    elif filename == "firstrun.ini":
+        return get_directory('birdnet_pi') + "/firstrun.ini"
+    ##
+    elif filename == ".gotty":
+        return get_directory('home') + "/.gotty"
+    ##
+    elif filename == "HUMAN.txt":
+        return get_directory('birdnet_pi') + "/HUMAN.txt"
+    ##
+    elif filename == "IdentifiedSoFar.txt" or filename == "IDFILE":
+        id_file_location = CONFIG.get('IDFILE')
+        return get_directory('home') + id_file_location.replace('$HOME', '')
+    ##
+    elif filename == "include_species_list.txt":
+        return get_directory('scripts') + "/include_species_list.txt"
+    ##
+    elif filename == "labels.txt" or filename == "labels.txt.old":
+        return get_directory('model') + '/' + filename
+    ##
+    elif filename == "labels_flickr.txt":
+        return get_directory('model') + "/labels_flickr.txt"
+    ##
+    elif filename == "labels_l18n.zip":
+        return get_directory('model') + "/labels_l18n.zip"
+    ##
+    elif filename == "labels_lang.txt":
+        return get_directory('model') + "/labels_lang.txt"
+    ##
+    elif filename == "labels_nm.zip":
+        return get_directory('model') + "/labels_nm.zip"
+    ##
+    elif filename == "lastrun.txt":
+        return get_directory('scripts') + "/lastrun.txt"
+    ##
+    elif filename == "python3":
+        return get_directory('python3_ve') + "/python3 "
+    ##
+    elif filename == "python3_appraise":
+        return get_directory('python3_ve') + "/apprise "
+    ##
+    elif filename == "species.py":
+        return get_directory('scripts') + "/species.py"
+    ##
+    elif filename == "thisrun.txt":
+        return get_directory('scripts') + "/thisrun.txt"
+    ##
+
+    return ""

--- a/tests/test_filepath_resolver.py
+++ b/tests/test_filepath_resolver.py
@@ -10,9 +10,10 @@ TEST_HOMES = ['/home/pi' '/home/another_user' '/opt/birdnet']
 def test():
     for _test_home in TEST_HOMES:
         # Override the home location
-        filepath_resolver.userDir = _test_home
+        filepath_resolver.home = _test_home
 
         # DIRECTORY TESTS
+        assert (filepath_resolver.get_directory('home') == _test_home)
         assert (filepath_resolver.get_directory('birdnet_pi') == _test_home + "/BirdNET-Pi")
         assert (filepath_resolver.get_directory('recs_dir') == _test_home + "/BirdSongs")
         assert (filepath_resolver.get_directory('processed') == _test_home + "/BirdSongs/Processed")
@@ -41,6 +42,7 @@ def test():
         assert (filepath_resolver.get_file_path('email_template2') == _test_home + "/BirdNET-Pi/scripts/email_template2")
         assert (filepath_resolver.get_file_path('exclude_species_list.txt') == _test_home + "/BirdNET-Pi/scripts/exclude_species_list.txt")
         assert (filepath_resolver.get_file_path('firstrun.ini') == _test_home + "/BirdNET-Pi/firstrun.ini")
+        assert (filepath_resolver.get_file_path('filepath_map.json') == _test_home + "/BirdNET-Pi/config/filepath_map.json")
         assert (filepath_resolver.get_file_path('.gotty') == _test_home + "/.gotty")
         assert (filepath_resolver.get_file_path('HUMAN.txt') == _test_home + "/BirdNET-Pi/HUMAN.txt")
         assert (filepath_resolver.get_file_path('IdentifiedSoFar.txt') == _test_home + "/BirdNET-Pi/IdentifiedSoFar.txt")
@@ -48,8 +50,8 @@ def test():
         assert (filepath_resolver.get_file_path('labels.txt') == _test_home + "/BirdNET-Pi/model/labels.txt")
         assert (filepath_resolver.get_file_path('labels.txt.old') == _test_home + "/BirdNET-Pi/model/labels.txt.old")
         assert (filepath_resolver.get_file_path('labels_flickr.txt') == _test_home + "/BirdNET-Pi/model/labels_flickr.txt")
-        assert (filepath_resolver.get_file_path('labels_l18n.zip') == _test_home + "/BirdNET-Pi/model/labels_l18n.zip")
         assert (filepath_resolver.get_file_path('labels_lang.txt') == _test_home + "/BirdNET-Pi/model/labels_lang.txt")
+        assert (filepath_resolver.get_file_path('labels_l18n.zip') == _test_home + "/BirdNET-Pi/model/labels_l18n.zip")
         assert (filepath_resolver.get_file_path('labels_nm.zip') == _test_home + "/BirdNET-Pi/model/labels_nm.zip")
         assert (filepath_resolver.get_file_path('lastrun.txt') == _test_home + "/BirdNET-Pi/scripts/lastrun.txt")
         assert (filepath_resolver.get_file_path('python3') == _test_home + "/BirdNET-Pi/birdnet/bin/python3 ")

--- a/tests/test_filepath_resolver.py
+++ b/tests/test_filepath_resolver.py
@@ -1,0 +1,58 @@
+from scripts.utils import filepath_resolver
+
+filepath_resolver.CONFIG = {"RECS_DIR": "$HOME/BirdSongs",
+                            "PROCESSED": "${RECS_DIR}/Processed",
+                            "EXTRACTED": "${RECS_DIR}/Extracted",
+                            "IDFILE": "$HOME/BirdNET-Pi/IdentifiedSoFar.txt"}
+
+TEST_HOMES = ['/home/pi' '/home/another_user' '/opt/birdnet']
+
+def test():
+    for _test_home in TEST_HOMES:
+        # Override the home location
+        filepath_resolver.userDir = _test_home
+
+        # DIRECTORY TESTS
+        assert (filepath_resolver.get_directory('birdnet_pi') == _test_home + "/BirdNET-Pi")
+        assert (filepath_resolver.get_directory('recs_dir') == _test_home + "/BirdSongs")
+        assert (filepath_resolver.get_directory('processed') == _test_home + "/BirdSongs/Processed")
+        assert (filepath_resolver.get_directory('extracted') == _test_home + "/BirdSongs/Extracted")
+        assert (filepath_resolver.get_directory('extracted_by_date') == _test_home + "/BirdSongs/Extracted/By_Date")
+        assert (filepath_resolver.get_directory('shifted_audio') == _test_home + "/BirdSongs/Extracted/By_Date/shifted")
+        assert (filepath_resolver.get_directory('database') == _test_home + "/BirdNET-Pi/database")
+        assert (filepath_resolver.get_directory('config') == _test_home + "/BirdNET-Pi/config")
+        assert (filepath_resolver.get_directory('models') == _test_home + "/BirdNET-Pi/model")
+        assert (filepath_resolver.get_directory('python3_ve') == _test_home + "/BirdNET-Pi/birdnet/bin")
+        assert (filepath_resolver.get_directory('scripts') == _test_home + "/BirdNET-Pi/scripts")
+        assert (filepath_resolver.get_directory('stream_data') == _test_home + "/BirdSongs/StreamData")
+        assert (filepath_resolver.get_directory('templates') == _test_home + "/BirdNET-Pi/templates")
+        assert (filepath_resolver.get_directory('web') == _test_home + "/BirdNET-Pi/homepage")
+
+        # FILE PATH TESTS
+        assert (filepath_resolver.get_file_path('analyzing_now.txt') == _test_home + "/BirdNET-Pi/analyzing_now.txt")
+        assert (filepath_resolver.get_file_path('apprise.txt') == _test_home + "/BirdNET-Pi/apprise.txt")
+        assert (filepath_resolver.get_file_path('birdnet.conf') == _test_home + "/BirdNET-Pi/birdnet.conf")
+        assert (filepath_resolver.get_file_path('etc_birdnet.conf') == "/etc/birdnet/birdnet.conf")
+        assert (filepath_resolver.get_file_path('BirdDB.txt') == _test_home + "/BirdNET-Pi/BirdDB.txt")
+        assert (filepath_resolver.get_file_path('birds.db') == _test_home + "/BirdNET-Pi/scripts/birds.db")
+        assert (filepath_resolver.get_file_path('blacklisted_images.txt') == _test_home + "/BirdNET-Pi/scripts/blacklisted_images.txt")
+        assert (filepath_resolver.get_file_path('disk_check_exclude.txt') == _test_home + "/BirdNET-Pi/scripts/disk_check_exclude.txt")
+        assert (filepath_resolver.get_file_path('email_template') == _test_home + "/BirdNET-Pi/scripts/email_template")
+        assert (filepath_resolver.get_file_path('email_template2') == _test_home + "/BirdNET-Pi/scripts/email_template2")
+        assert (filepath_resolver.get_file_path('exclude_species_list.txt') == _test_home + "/BirdNET-Pi/scripts/exclude_species_list.txt")
+        assert (filepath_resolver.get_file_path('firstrun.ini') == _test_home + "/BirdNET-Pi/firstrun.ini")
+        assert (filepath_resolver.get_file_path('.gotty') == _test_home + "/.gotty")
+        assert (filepath_resolver.get_file_path('HUMAN.txt') == _test_home + "/BirdNET-Pi/HUMAN.txt")
+        assert (filepath_resolver.get_file_path('IdentifiedSoFar.txt') == _test_home + "/BirdNET-Pi/IdentifiedSoFar.txt")
+        assert (filepath_resolver.get_file_path('include_species_list.txt') == _test_home + "/BirdNET-Pi/scripts/include_species_list.txt")
+        assert (filepath_resolver.get_file_path('labels.txt') == _test_home + "/BirdNET-Pi/model/labels.txt")
+        assert (filepath_resolver.get_file_path('labels.txt.old') == _test_home + "/BirdNET-Pi/model/labels.txt.old")
+        assert (filepath_resolver.get_file_path('labels_flickr.txt') == _test_home + "/BirdNET-Pi/model/labels_flickr.txt")
+        assert (filepath_resolver.get_file_path('labels_l18n.zip') == _test_home + "/BirdNET-Pi/model/labels_l18n.zip")
+        assert (filepath_resolver.get_file_path('labels_lang.txt') == _test_home + "/BirdNET-Pi/model/labels_lang.txt")
+        assert (filepath_resolver.get_file_path('labels_nm.zip') == _test_home + "/BirdNET-Pi/model/labels_nm.zip")
+        assert (filepath_resolver.get_file_path('lastrun.txt') == _test_home + "/BirdNET-Pi/scripts/lastrun.txt")
+        assert (filepath_resolver.get_file_path('python3') == _test_home + "/BirdNET-Pi/birdnet/bin/python3 ")
+        assert (filepath_resolver.get_file_path('python3_appraise') == _test_home + "/BirdNET-Pi/birdnet/bin/apprise ")
+        assert (filepath_resolver.get_file_path('species.py') == _test_home + "/BirdNET-Pi/scripts/species.py")
+        assert (filepath_resolver.get_file_path('thisrun.txt') == _test_home + "/BirdNET-Pi/scripts/thisrun.txt")


### PR DESCRIPTION
Created a file path and directory resolver that can be called with a file name or directory and returns a path relative to a home path, which is still currently fixed to the use executing the scripts but the idea that now this can be easily changed.
This resolver is practically identical to the one created in #925

Updated the 4 only python scripts to use this resolver when looking for the bird.db path, models, labels.txt etc etc

Included test_filepath_resolver.py which runs a simple list of tests against the new get_file_path and get_directory to ensure they return what we expect
The script should return nothing if all was ok

All scripts have been tested and work fine on my install but testing still required, Comments/suggestions welcome.

Relies upon #925 for config/filepath_map.json