### PR TITLE
Bash Scripts - Create a file path and directory resolver & migrate away from hard coded paths

### DIFF
--- a/scripts/birdnet_recording.sh
+++ b/scripts/birdnet_recording.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/common.sh
+
 # Performs the recording from the specified RTSP stream or soundcard
 source /etc/birdnet/birdnet.conf
+
+STREAM_DATA_DIR="$(getDirectory 'stream_data')"
+RECORDINGS_DIR="$(getDirectory 'recs_dir')"
 
 # Read the logging level from the configuration option
 LOGGING_LEVEL="${LogLevel_BirdnetRecordingService}"
@@ -15,7 +21,7 @@ fi
 [ -z $RECORDING_LENGTH ] && RECORDING_LENGTH=15
 
 if [ ! -z $RTSP_STREAM ];then
-  [ -d $RECS_DIR/StreamData ] || mkdir -p $RECS_DIR/StreamData
+  [ -d $STREAM_DATA_DIR ] || mkdir -p $STREAM_DATA_DIR
   # Explode the RSPT steam setting into an array so we can count the number we have
   RTSP_STREAMS_EXPLODED_ARRAY=(${RTSP_STREAM//,/ })
 
@@ -35,7 +41,7 @@ if [ ! -z $RTSP_STREAM ];then
       # Map id used to map input to output (first stream being 0), this is 0 based in ffmpeg so decrement our counter (which is more human readable) by 1
       MAP_ID=$((RTSP_STREAMS_STARTED_COUNT-1))
       # Build up the parameters to process the RSTP stream, including mapping for the output
-      FFMPEG_PARAMS+="-vn -thread_queue_size 512 -i ${i} -map ${MAP_ID}:a:0 -t ${RECORDING_LENGTH} -acodec pcm_s16le -ac 2 -ar 48000 file:${RECS_DIR}/StreamData/$(date "+%F")-birdnet-RTSP_${RTSP_STREAMS_STARTED_COUNT}-$(date "+%H:%M:%S").wav "
+      FFMPEG_PARAMS+="-vn -thread_queue_size 512 -i ${i} -map ${MAP_ID}:a:0 -t ${RECORDING_LENGTH} -acodec pcm_s16le -ac 2 -ar 48000 file:${STREAM_DATA_DIR}/$(date "+%F")-birdnet-RTSP_${RTSP_STREAMS_STARTED_COUNT}-$(date "+%H:%M:%S").wav "
       # Increment counter
       ((RTSP_STREAMS_STARTED_COUNT += 1))
     done
@@ -56,11 +62,11 @@ else
     done
     if [ -z ${REC_CARD} ];then
       arecord -f S16_LE -c${CHANNELS} -r48000 -t wav --max-file-time ${RECORDING_LENGTH}\
-	      --use-strftime ${RECS_DIR}/%B-%Y/%d-%A/%F-birdnet-%H:%M:%S.wav
+	      --use-strftime ${RECORDINGS_DIR}/%B-%Y/%d-%A/%F-birdnet-%H:%M:%S.wav
     else
       arecord -f S16_LE -c${CHANNELS} -r48000 -t wav --max-file-time ${RECORDING_LENGTH}\
         -D "${REC_CARD}" --use-strftime \
-	${RECS_DIR}/%B-%Y/%d-%A/%F-birdnet-%H:%M:%S.wav
+	${RECORDINGS_DIR}/%B-%Y/%d-%A/%F-birdnet-%H:%M:%S.wav
     fi
   fi
 fi

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,18 +1,23 @@
 #!/usr/bin/env bash
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/common.sh
+
+PROCESSED_DIR="$(getDirectory 'processed')"
+
 source /etc/birdnet/birdnet.conf
 set -x
 
-cd "${PROCESSED}" || exit 1
-empties=($(find ${PROCESSED} -size 57c))
+cd "${PROCESSED_DIR}" || exit 1
+empties=($(find ${PROCESSED_DIR} -size 57c))
 for i in "${empties[@]}";do
   rm -f "${i}"
   rm -f "${i/.csv/}"
 done
 
-if [[ "$(find ${PROCESSED} | wc -l)" -ge 100 ]];then
+if [[ "$(find ${PROCESSED_DIR} | wc -l)" -ge 100 ]];then
   ls -1t . | tail -n +100 | xargs -r rm -vv
 fi
 
-#accumulated_files=$(find $RECS_DIR -path $PROCESSED -prune -o -path $EXTRACTED -prune -o -type f -print | wc -l)
+#accumulated_files=$(find $RECS_DIR -path $PROCESSED_DIR -prune -o -path $EXTRACTED -prune -o -type f -print | wc -l)
 #[ $accumulated_files -ge 10 ] && stop_core_services.sh
 #echo "$(date "+%b  %e %I:%M:%S") Stopped Core Services -- It looks like analysis stopped. Check raw recordings in $RECS_DIR and check the birdnet_analysis.service and birdnet_server.service \"journalctl -eu birdnet_analysis -u birdnet_server\"" | sudo tee -a /var/log/syslog

--- a/scripts/clear_all_data.sh
+++ b/scripts/clear_all_data.sh
@@ -1,55 +1,67 @@
 #!/usr/bin/env bash
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/common.sh
+
+USER=$(awk -F: '/1000/ {print $1}' /etc/passwd)
+HOME=$(awk -F: '/1000/ {print $6}' /etc/passwd)
+SCRIPTS_DIR="$(getDirectory 'scripts')"
+HOME_DIR="$(getDirectory 'home')"
+BIRDNET_PI_DIR="$(getDirectory 'birdnet_pi')"
+RECORDING_DIR="$(getDirectory 'recs_dir')"
+EXTRACTED_DIR="$(getDirectory 'extracted')"
+id_file_path="$(getFilePath 'IDFILE')"
+bird_db_txt_path="$(getFilePath 'BirdDB.txt')"
+
+source /etc/birdnet/birdnet.conf
+
 # This script removes all data that has been collected. It is tantamount to
 # starting all data-collection from scratch. Only run this if you are sure
 # you are okay will losing all the data that you've collected and processed
 # so far.
 set -x
-source /etc/birdnet/birdnet.conf
-USER=$(awk -F: '/1000/ {print $1}' /etc/passwd)
-HOME=$(awk -F: '/1000/ {print $6}' /etc/passwd)
-my_dir=${HOME}/BirdNET-Pi/scripts
+
 echo "Stopping services"
 sudo systemctl stop birdnet_recording.service
 sudo systemctl stop birdnet_analysis.service
 sudo systemctl stop birdnet_server.service
 echo "Removing all data . . . "
-sudo rm -drf "${RECS_DIR}"
-sudo rm -f "${IDFILE}"
-sudo rm -f $(dirname ${my_dir})/BirdDB.txt
+sudo rm -drf "${RECORDING_DIR}"
+sudo rm -f "${id_file_path}"
+sudo rm -f "${bird_db_txt_path}"
 
 echo "Re-creating necessary directories"
-[ -d ${EXTRACTED} ] || sudo -u ${USER} mkdir -p ${EXTRACTED}
-[ -d ${EXTRACTED}/By_Date ] || sudo -u ${USER} mkdir -p ${EXTRACTED}/By_Date
-[ -d ${EXTRACTED}/Charts ] || sudo -u ${USER} mkdir -p ${EXTRACTED}/Charts
-[ -d ${PROCESSED} ] || sudo -u ${USER} mkdir -p ${PROCESSED}
+[ -d ${EXTRACTED_DIR} ] || sudo -u ${USER} mkdir -p ${EXTRACTED_DIR}
+[ -d ${EXTRACTED_DIR}/By_Date ] || sudo -u ${USER} mkdir -p ${EXTRACTED_DIR}/By_Date
+[ -d ${EXTRACTED_DIR}/Charts ] || sudo -u ${USER} mkdir -p ${EXTRACTED_DIR}/Charts
+[ -d ${EXTRACTED_DIR} ] || sudo -u ${USER} mkdir -p ${EXTRACTED_DIR}
 
-sudo -u ${USER} ln -fs $(dirname $my_dir)/exclude_species_list.txt $my_dir
-sudo -u ${USER} ln -fs $(dirname $my_dir)/include_species_list.txt $my_dir
-sudo -u ${USER} ln -fs $(dirname $my_dir)/homepage/* ${EXTRACTED}
-sudo -u ${USER} ln -fs $(dirname $my_dir)/model/labels.txt ${my_dir}
-sudo -u ${USER} ln -fs $my_dir ${EXTRACTED}
-sudo -u ${USER} ln -fs $my_dir/play.php ${EXTRACTED}
-sudo -u ${USER} ln -fs $my_dir/spectrogram.php ${EXTRACTED}
-sudo -u ${USER} ln -fs $my_dir/overview.php ${EXTRACTED}
-sudo -u ${USER} ln -fs $my_dir/stats.php ${EXTRACTED}
-sudo -u ${USER} ln -fs $my_dir/todays_detections.php ${EXTRACTED}
-sudo -u ${USER} ln -fs $my_dir/history.php ${EXTRACTED}
-sudo -u ${USER} ln -fs $my_dir/weekly_report.php ${EXTRACTED}
-sudo -u ${USER} ln -fs $my_dir/homepage/images/favicon.ico ${EXTRACTED}
-sudo -u ${USER} ln -fs ${HOME}/phpsysinfo ${EXTRACTED}
-sudo -u ${USER} ln -fs $(dirname $my_dir)/templates/phpsysinfo.ini ${HOME}/phpsysinfo/
-sudo -u ${USER} ln -fs $(dirname $my_dir)/templates/green_bootstrap.css ${HOME}/phpsysinfo/templates/
-sudo -u ${USER} ln -fs $(dirname $my_dir)/templates/index_bootstrap.html ${HOME}/phpsysinfo/templates/html
-chmod -R g+rw $my_dir
-chmod -R g+rw ${RECS_DIR}
+sudo -u ${USER} ln -fs $BIRDNET_PI_DIR/exclude_species_list.txt $SCRIPTS_DIR
+sudo -u ${USER} ln -fs $BIRDNET_PI_DIR/include_species_list.txt $SCRIPTS_DIR
+sudo -u ${USER} ln -fs $BIRDNET_PI_DIR/homepage/* ${EXTRACTED_DIR}
+sudo -u ${USER} ln -fs $BIRDNET_PI_DIR/model/labels.txt ${SCRIPTS_DIR}
+sudo -u ${USER} ln -fs $SCRIPTS_DIR ${EXTRACTED_DIR}
+sudo -u ${USER} ln -fs $SCRIPTS_DIR/play.php ${EXTRACTED_DIR}
+sudo -u ${USER} ln -fs $SCRIPTS_DIR/spectrogram.php ${EXTRACTED_DIR}
+sudo -u ${USER} ln -fs $SCRIPTS_DIR/overview.php ${EXTRACTED_DIR}
+sudo -u ${USER} ln -fs $SCRIPTS_DIR/stats.php ${EXTRACTED_DIR}
+sudo -u ${USER} ln -fs $SCRIPTS_DIR/todays_detections.php ${EXTRACTED_DIR}
+sudo -u ${USER} ln -fs $SCRIPTS_DIR/history.php ${EXTRACTED_DIR}
+sudo -u ${USER} ln -fs $SCRIPTS_DIR/weekly_report.php ${EXTRACTED_DIR}
+sudo -u ${USER} ln -fs $SCRIPTS_DIR/homepage/images/favicon.ico ${EXTRACTED_DIR}
+sudo -u ${USER} ln -fs $HOME_DIR/phpsysinfo ${EXTRACTED_DIR}
+sudo -u ${USER} ln -fs $BIRDNET_PI_DIR/templates/phpsysinfo.ini ${HOME_DIR}/phpsysinfo/
+sudo -u ${USER} ln -fs $BIRDNET_PI_DIR/templates/green_bootstrap.css ${HOME_DIR}/phpsysinfo/templates/
+sudo -u ${USER} ln -fs $BIRDNET_PI_DIR/templates/index_bootstrap.html ${HOME_DIR}/phpsysinfo/templates/html
+chmod -R g+rw $SCRIPTS_DIR
+chmod -R g+rw $RECORDING_DIR
 
 
 echo "Dropping and re-creating database"
 createdb.sh
 echo "Re-generating BirdDB.txt"
-touch $(dirname ${my_dir})/BirdDB.txt
-echo "Date;Time;Sci_Name;Com_Name;Confidence;Lat;Lon;Cutoff;Week;Sens;Overlap" > $(dirname ${my_dir})/BirdDB.txt
-ln -sf $(dirname ${my_dir})/BirdDB.txt ${my_dir}/BirdDB.txt
-chown $USER:$USER ${my_dir}/BirdDB.txt && chmod g+rw ${my_dir}/BirdDB.txt
+touch "${bird_db_txt_path}"
+echo "Date;Time;Sci_Name;Com_Name;Confidence;Lat;Lon;Cutoff;Week;Sens;Overlap" > "${bird_db_txt_path}"
+ln -sf ${bird_db_txt_path} "${SCRIPTS_DIR}/BirdDB.txt"
+chown $USER:$USER "${SCRIPTS_DIR}/BirdDB.txt" && chmod g+rw "${SCRIPTS_DIR}/BirdDB.txt"
 echo "Restarting services"
-restart_services.sh
+#restart_services.sh

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
+BINDIR_COMMON=$(cd $(dirname $0) && pwd)
 # Load config and settings
 source /etc/birdnet/birdnet.conf
-#source ./birdnet.conf
 # $HOME here is home of the user executing the script
 EXPANDED_HOME=$HOME
 
@@ -12,67 +12,141 @@ HOME=$(awk -F: '/1000/ {print $6}' /etc/passwd)
 # If script is being run as sudo get the home path for the user that's running sudo
 #if [ $SUDO_USER ]; then HOME=$(getent passwd $SUDO_USER | cut -d: -f6); fi
 
+filePathMap_data=""
+# Test some paths to see where the config file is accessible
+# First try find the config folder under the current working directory where this file is executing, else find it the current working directory BUT up 1 level
+# else find it under the current working directory
+if [ -f "${BINDIR_COMMON}/config/filepath_map.json" ]; then
+  filePathMap_json_path="${BINDIR_COMMON}/config/filepath_map.json"
+elif [ -f "${PWD%/*}/config/filepath_map.json" ]; then
+  filePathMap_json_path="${PWD%/*}/config/filepath_map.json"
+else
+  filePathMap_json_path="${PWD%}/config/filepath_map.json"
+fi
+
+loadFilePathMap() {
+  #Loads in the JSON file containing data on directory and file paths
+  if [ -z "$filePathMap_data" ]; then
+    # Test if jq is installed
+    test_json_str=$(echo "{ }" | jq)
+    if [ "$test_json_str" != "{}" ]; then
+      echo "jq command-line JSON processor is not installed, Install it with; sudo apt-get install jq"
+      exit 1
+    fi
+
+    # Test if the path to the JSON file is valud
+    if [ ! -f "$filePathMap_json_path" ]; then
+      echo "Specified JSON file $filePathMap_json_path does not exist"
+      exit 2
+    fi
+
+    # Read in the JSON file
+    filePathMap_data=$(cat "$filePathMap_json_path")
+  fi
+}
+
+readJsonConfig() {
+  # Reads the filepath_map JSON file and processes it with jq
+  loadFilePathMap
+  echo $filePathMap_data | jq -r "$1"
+}
+
+readJsonElement() {
+  # Read a specific element from the supplied JSON string
+  # $1 is the JSON string and $2 is the value to read
+  # e.g $1 = {"description": "The home path for the user with User ID of 1000, this is normally the 'pi' user",  "read_setting": null,  "return_var": "home" }
+  # e.g $2 = '.description'
+  # will return the description from the JSON array
+  echo "$1" | jq -r "$2"
+}
 
 getDirectory() {
   DIR_NAME=$1
   DIR_NAME=$(echo "$DIR_NAME" | tr '[:upper:]' '[:lower:]')
 
-  if [ "$DIR_NAME" = "home" ]; then
-    echo $HOME
-    ##
-  elif [ "$DIR_NAME" = "birdnet-pi" ] || [ "$DIR_NAME" = "birdnet_pi" ]; then
-    echo "$(getDirectory 'home')/BirdNET-Pi"
-    ##
-  elif [ "$DIR_NAME" = "recs_dir" ] || [ "$DIR_NAME" = "recordings_dir" ]; then
-    home_dir="$(getDirectory 'home')"
-    recs_dir_setting=$RECS_DIR
-    echo ${recs_dir_setting//$EXPANDED_HOME/$home_dir}
-    ##
-  elif [ "$DIR_NAME" = "processed" ]; then
-    #replace the entire ${RECS_DIR} expansion as it is expanded on $HOME of the user executing the script
-    #this may or may not be correct, so we want to be able to replace it and put in place the calculated recordings dir
-    processed_dir_setting=${PROCESSED//"$EXPANDED_HOME/BirdSongs"/""}
-    echo "$(getDirectory 'recs_dir')${processed_dir_setting//"$(getDirectory 'recs_dir')"/}"
-    ##
-  elif [ "$DIR_NAME" = "extracted" ]; then
-    #replace the entire ${RECS_DIR} expansion as it is expanded on $HOME of the user executing the script
-    #this may or may not be correct, so we want to be able to replace it and put in place the calculated recordings dir
-    home_dir="$(getDirectory 'home')"
-    extracted_dir_setting=${EXTRACTED//"$EXPANDED_HOME/BirdSongs"/""}
-    echo "$(getDirectory 'recs_dir')${extracted_dir_setting//"$(getDirectory 'recs_dir')"/}"
-    ##
-  elif [ "$DIR_NAME" = "extracted_bydate" ] || [ "$DIR_NAME" = "extracted_by_date" ]; then
-    echo "$(getDirectory 'extracted')/By_Date"
-    ##
-  elif [ "$DIR_NAME" = "shifted_audio" ] || [ "$DIR_NAME" = "shifted_dir" ]; then
-    echo "$(getDirectory 'home')/BirdSongs/Extracted/By_Date/shifted"
-    ##
-  elif [ "$DIR_NAME" = "database" ]; then
-    #		 NOT USED
-    echo "$(getDirectory 'birdnet_pi')/database"
-    ##
-  elif [ "$DIR_NAME" = "config" ]; then
-    #		 NOT USED
-    echo "$(getDirectory 'birdnet_pi')/config"
-    ##
-  elif [ "$DIR_NAME" = "models" ] || [ "$DIR_NAME" = "model" ]; then
-    echo "$(getDirectory 'birdnet_pi')/model"
-    ##
-  elif [ "$DIR_NAME" = "python3_ve" ]; then
-    echo "$(getDirectory 'birdnet_pi')/birdnet/bin"
-    ##
-  elif [ "$DIR_NAME" = "scripts" ]; then
-    echo "$(getDirectory 'birdnet_pi')/scripts"
-    ##
-  elif [ "$DIR_NAME" = "stream_data" ]; then
-    echo "$(getDirectory 'recs_dir')/StreamData"
-    ##
-  elif [ "$DIR_NAME" = "templates" ]; then
-    echo "$(getDirectory 'birdnet_pi')/templates"
-    ##
-  elif [ "$DIR_NAME" = "web" ] || [ "$DIR_NAME" = "www" ]; then
-    echo "$(getDirectory 'birdnet_pi')/homepage"
-    ##
+  filePathMap_directories=$(readJsonConfig ".directories")
+
+  if [ "${filePathMap_directories[$DIR_NAME]}" ]; then
+    filePathMap_directories_selected=$(readJsonElement "$filePathMap_directories" ".$DIR_NAME")
+
+    # Check to see if directory is an alias for another
+    test_dir_alias="$(readJsonElement "$filePathMap_directories_selected" ".alias_for")"
+    if [ -n "$test_dir_alias" ] && [ "$test_dir_alias" != "null" ]; then
+      # If so load in the data for that directory
+      filePathMap_directories_selected=$(readJsonElement "$filePathMap_directories" ".$test_dir_alias")
+    fi
+
+    # Read in all the options from the JSON string at once
+    filePathMap_directory_options="$(readJsonElement "$filePathMap_directories_selected" ".read_setting , .lives_under , .replace_setting_text , .replace_setting_text_with , .append , .return_var")"
+    # Split the string by newlines into an array so we can access individual elements
+    readarray -t ElementArray <<<"$filePathMap_directory_options"
+
+    # Gather all the options into variables
+    test_read_setting="${ElementArray[0]}"
+    test_lives_under="${ElementArray[1]}"
+    test_replace_setting_text="${ElementArray[2]}"
+    test_replace_setting_text_with="${ElementArray[3]}"
+    test_append="${ElementArray[4]}"
+    test_return_var="${ElementArray[5]}"
+    #
+    if [ -n "$test_read_setting" ] && [ "$test_read_setting" != "null" ]; then setting_value="$test_read_setting"; else setting_value=""; fi
+    if [ -n "$test_lives_under" ] && [ "$test_lives_under" != "null" ]; then lives_under="$test_lives_under"; else lives_under=""; fi
+    if [ -n "$test_replace_setting_text" ] && [ "$test_replace_setting_text" != "null" ]; then replace_text="$test_replace_setting_text"; else replace_text=""; fi
+    if [ -n "$test_replace_setting_text_with" ] && [ "$test_replace_setting_text_with" != "null" ]; then replace_test_with="$test_replace_setting_text_with"; else replace_test_with=""; fi
+    if [ -n "$test_append" ] && [ "$test_append" != "null" ]; then append="$test_append"; else append=""; fi
+    if [ -n "$test_return_var" ] && [ "$test_return_var" != "null" ]; then return_val="$test_return_var"; else return_val=""; fi
+    #
+    under_directory=''
+
+    # Get the directory which the directory we're processing lives under
+    if [ -n "$lives_under" ]; then
+      under_directory=$(getDirectory "$lives_under")
+    fi
+
+    # Read the specified config file setting if any
+    if [ -n "$setting_value" ]; then
+      setting_value="${!setting_value}"
+    fi
+
+    # Replace value in setting, like ${RECS_DIR} etc as they are not expanded
+    if [ -n "$replace_text" ]; then
+      # remove characters that represent a pre-expanded variable, eg ${RECS_DIR} in the ini file will expand correctly to the e.g /home/pi/BirdSongs
+      # but in other languages like  it remains as ${RECS_DIR} as no expansion takes place, The pre-expanded variable is used in the filepat map
+      replace_text=${replace_text//"\$"/""}
+      replace_text=${replace_text//"{"/""}
+      replace_text=${replace_text//"}"/""}
+
+      # Now we have the actual variable name, expand it to read it's value
+      replace_val=${!replace_text}
+      #replace the entire ${RECS_DIR} expansion as it is expanded on $HOME of the user executing the script
+      #this may or may not be correct, so we want to be able to replace it and put in place the calculated recordings dir
+      return_value=${setting_value//"$replace_val"/"$replace_test_with"}
+
+      # Replace the home path part of the setting value as it was expanded using ENV variables for the user executing this script
+      # This allows the under_directory to be prepended to whatever is left
+      return_value=${return_value//"$EXPANDED_HOME"/""}
+    else
+      return_value=$setting_value
+    fi
+
+    # If a variable is specified for return, return it first and directly
+    if [ -n "$return_val" ]; then
+      #test if trying to read the variable works in it's current form. e.g 'home'
+      if [ -z "${!return_val}" ]; then
+        # uppercase the to be variable name so it matches a variable in the current session 'home' => 'HOME'
+        # e.g which will match the users HOME location specified at the start of this script
+        return_val="$(echo "$return_val" | tr '[:lower:]' '[:upper:]')"
+      fi
+
+      # return the dynamic variable, currently this is just the users home path in $home
+      echo "${!return_val}"
+    elif [ -n "$append" ]; then
+      # Append this to the end of the path, (models, scripts etc) do this as they reside under BirdNET-pi
+      echo "$under_directory$append"
+    else
+      # Else return the directory and result of the setting manipulation
+      echo "$under_directory$return_value"
+    fi
   else
     echo
   fi
@@ -80,86 +154,79 @@ getDirectory() {
 
 getFilePath() {
   FILENAME=$1
+  # Manipulate the filename to accommodate filenames which inherently have periods in the filename
+  # https://stedolan.github.io/jq/manual/#Basicfilters
+  FILENAME=".\"$FILENAME\""
 
-  if [ "$FILENAME" = "analyzing_now.txt" ]; then
-    echo "$(getDirectory 'birdnet_pi')/analyzing_now.txt"
-    ##
-  elif [ "$FILENAME" = "apprise.txt" ]; then
-    echo "$(getDirectory 'birdnet_pi')/apprise.txt"
-    ##
-  elif [ "$FILENAME" = "birdnet.conf" ]; then
-    echo "$(getDirectory 'birdnet_pi')/birdnet.conf"
-    ##
-  elif [ "$FILENAME" = "etc_birdnet.conf" ]; then
-    echo "/etc/birdnet/birdnet.conf"
-    ##
-  elif [ "$FILENAME" = "BirdDB.txt" ]; then
-    echo "$(getDirectory 'birdnet_pi')/BirdDB.txt"
-    ##
-  elif [ "$FILENAME" = "birds.db" ]; then
-    echo "$(getDirectory 'scripts')/birds.db"
-    ##
-  elif [ "$FILENAME" = "blacklisted_images.txt" ]; then
-    echo "$(getDirectory 'scripts')/blacklisted_images.txt"
-    ##
-  elif [ "$FILENAME" = "disk_check_exclude.txt" ]; then
-    echo "$(getDirectory 'scripts')/disk_check_exclude.txt"
-    ##
-  elif [ "$FILENAME" = "email_template" ]; then
-    echo "$(getDirectory 'scripts')/email_template"
-    ##
-  elif [ "$FILENAME" = "email_template2" ]; then
-    echo "$(getDirectory 'scripts')/email_template2"
-    ##
-  elif [ "$FILENAME" = "exclude_species_list.txt" ]; then
-    echo "$(getDirectory 'scripts')/exclude_species_list.txt"
-    ##
-  elif [ "$FILENAME" = "firstrun.ini" ]; then
-    echo "$(getDirectory 'birdnet_pi')/firstrun.ini"
-    ##
-  elif [ "$FILENAME" = ".gotty" ]; then
-    echo "$(getDirectory 'home')/.gotty"
-  ##
-  elif [ "$FILENAME" = "HUMAN.txt" ]; then
-    echo "$(getDirectory 'birdnet_pi')/HUMAN.txt"
-    ##
-  elif [ "$FILENAME" = "IdentifiedSoFar.txt" ] || [ "$FILENAME" = "IDFILE" ]; then
-    id_home_dir=$(getDirectory 'home')
-    echo "${IDFILE//$EXPANDED_HOME/$id_home_dir}"
-  ##
-  elif [ "$FILENAME" = "include_species_list.txt" ]; then
-    echo "$(getDirectory 'scripts')/include_species_list.txt"
-    ##
-  elif [ "$FILENAME" = "labels.txt" ] || [ "$FILENAME" = "labels.txt.old" ]; then
-    echo "$(getDirectory 'model')/$FILENAME"
-    ##
-  elif [ "$FILENAME" = "labels_flickr.txt" ]; then
-    echo "$(getDirectory 'model')/labels_flickr.txt"
-    ##
-  elif [ "$FILENAME" = "labels_l18n.zip" ]; then
-    echo "$(getDirectory 'model')/labels_l18n.zip"
-    ##
-  elif [ "$FILENAME" = "labels_lang.txt" ]; then
-    echo "$(getDirectory 'model')/labels_lang.txt"
-    ##
-  elif [ "$FILENAME" = "labels_nm.zip" ]; then
-    echo "$(getDirectory 'model')/labels_nm.zip"
-    ##
-  elif [ "$FILENAME" = "lastrun.txt" ]; then
-    echo "$(getDirectory 'scripts')/lastrun.txt"
-    ##
-  elif [ "$FILENAME" = "python3" ]; then
-    echo "$(getDirectory 'python3_ve')/python3 "
-    ##
-  elif [ "$FILENAME" = "python3_appraise" ]; then
-    echo "$(getDirectory 'python3_ve')/apprise "
-    ##
-  elif [ "$FILENAME" = "species.py" ]; then
-    echo "$(getDirectory 'scripts')/species.py"
-    ##
-  elif [ "$FILENAME" = "thisrun.txt" ]; then
-    echo "$(getDirectory 'scripts')/thisrun.txt"
-    ##
+  filePathMap_files=$(readJsonConfig ".files")
+  # Check and make sure the supplied filename exists before further processing
+  test_file_key_exists="$(readJsonElement "$filePathMap_files" $FILENAME)"
+  if [ -n "$test_file_key_exists" ] && [ "$test_file_key_exists" != "null" ]; then
+    filePathMap_file_selected=$test_file_key_exists
+
+    # Read in all the options from the JSON string at once
+    filePathMap_file_options="$(readJsonElement "$filePathMap_file_selected" ".read_setting , .lives_under , .replace_setting_text , .replace_setting_text_with , .append , .return_var")"
+    # Split the string by newlines into an array so we can access individual elements
+    readarray -t ElementArray <<<"$filePathMap_file_options"
+
+    # Gather all the options into variables, array indexes are in order of how the values were read by readJsonElement
+    test_read_setting="${ElementArray[0]}"
+    test_lives_under="${ElementArray[1]}"
+    test_replace_setting_text="${ElementArray[2]}"
+    test_replace_setting_text_with="${ElementArray[3]}"
+    test_append="${ElementArray[4]}"
+    test_return_var="${ElementArray[5]}"
+    #
+    if [ -n "$test_read_setting" ] && [ "$test_read_setting" != "null" ]; then setting_value="$test_read_setting"; else setting_value=""; fi
+    if [ -n "$test_lives_under" ] && [ "$test_lives_under" != "null" ]; then lives_under="$test_lives_under"; else lives_under=""; fi
+    if [ -n "$test_replace_setting_text" ] && [ "$test_replace_setting_text" != "null" ]; then replace_text="$test_replace_setting_text"; else replace_text=""; fi
+    if [ -n "$test_replace_setting_text_with" ] && [ "$test_replace_setting_text_with" != "null" ]; then replace_test_with="$test_replace_setting_text_with"; else replace_test_with=""; fi
+    if [ -n "$test_append" ] && [ "$test_append" != "null" ]; then append="$test_append"; else append=""; fi
+    if [ -n "$test_return_var" ] && [ "$test_return_var" != "null" ]; then return_val="$test_return_var"; else return_val=""; fi
+    #
+    under_directory=''
+
+    # Get the directory which the directory we're processing lives under
+    if [ -n "$lives_under" ]; then
+      under_directory=$(getDirectory "$lives_under")
+    fi
+
+    # Read the specified config file setting if any
+    if [ -n "$setting_value" ]; then
+      setting_value="${!setting_value}"
+    fi
+
+    # Replace value in setting, like ${RECS_DIR} etc as they are not expanded
+    if [ -n "$replace_text" ]; then
+      # remove characters that represent a pre-expanded variable, eg ${RECS_DIR} in the ini file will expand correctly to the e.g /home/pi/BirdSongs
+      # but in other languages like  it remains as ${RECS_DIR} as no expansion takes place, The pre-expanded variable is used in the filepat map
+      replace_text=${replace_text//"\$"/""}
+      replace_text=${replace_text//"{"/""}
+      replace_text=${replace_text//"}"/""}
+
+      # Now we have the actual variable name, expand it to read it's value
+      replace_val=${!replace_text}
+      #replace the entire ${RECS_DIR} expansion as it is expanded on $HOME of the user executing the script
+      #this may or may not be correct, so we want to be able to replace it and put in place the calculated recordings dir
+      return_value=${setting_value//"$replace_val"/"$replace_test_with"}
+
+      # Replace the home path part of the setting value as it was expanded using ENV variables for the user executing this script
+      # This allows the under_directory to be prepended to whatever is left
+      return_value=${return_value//"$EXPANDED_HOME"/""}
+    else
+      return_value=$setting_value
+    fi
+
+    if [ -n "$return_val" ]; then
+      # If a value has been specified for return, return it first
+      echo "$return_val"
+    elif [ -n "$append" ]; then
+      # Append this to the end of the path, (models, scripts etc) do this as they reside under BirdNET-pi
+      echo "$under_directory$append"
+    else
+      # Else return the directory and result of the setting manipulation
+      echo "$under_directory$return_value"
+    fi
   else
     echo
   fi

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Load config and settings
+source /etc/birdnet/birdnet.conf
+#source ./birdnet.conf
+# $HOME here is home of the user executing the script
+EXPANDED_HOME=$HOME
+
+# Get the user and home directory of the user with id 1000 (normally pi)
+USER=$(awk -F: '/1000/ {print $1}' /etc/passwd)
+HOME=$(awk -F: '/1000/ {print $6}' /etc/passwd)
+
+# If script is being run as sudo get the home path for the user that's running sudo
+#if [ $SUDO_USER ]; then HOME=$(getent passwd $SUDO_USER | cut -d: -f6); fi
+
+
+getDirectory() {
+  DIR_NAME=$1
+  DIR_NAME=$(echo "$DIR_NAME" | tr '[:upper:]' '[:lower:]')
+
+  if [ "$DIR_NAME" = "home" ]; then
+    echo $HOME
+    ##
+  elif [ "$DIR_NAME" = "birdnet-pi" ] || [ "$DIR_NAME" = "birdnet_pi" ]; then
+    echo "$(getDirectory 'home')/BirdNET-Pi"
+    ##
+  elif [ "$DIR_NAME" = "recs_dir" ] || [ "$DIR_NAME" = "recordings_dir" ]; then
+    home_dir="$(getDirectory 'home')"
+    recs_dir_setting=$RECS_DIR
+    echo ${recs_dir_setting//$EXPANDED_HOME/$home_dir}
+    ##
+  elif [ "$DIR_NAME" = "processed" ]; then
+    #replace the entire ${RECS_DIR} expansion as it is expanded on $HOME of the user executing the script
+    #this may or may not be correct, so we want to be able to replace it and put in place the calculated recordings dir
+    processed_dir_setting=${PROCESSED//"$EXPANDED_HOME/BirdSongs"/""}
+    echo "$(getDirectory 'recs_dir')${processed_dir_setting//"$(getDirectory 'recs_dir')"/}"
+    ##
+  elif [ "$DIR_NAME" = "extracted" ]; then
+    #replace the entire ${RECS_DIR} expansion as it is expanded on $HOME of the user executing the script
+    #this may or may not be correct, so we want to be able to replace it and put in place the calculated recordings dir
+    home_dir="$(getDirectory 'home')"
+    extracted_dir_setting=${EXTRACTED//"$EXPANDED_HOME/BirdSongs"/""}
+    echo "$(getDirectory 'recs_dir')${extracted_dir_setting//"$(getDirectory 'recs_dir')"/}"
+    ##
+  elif [ "$DIR_NAME" = "extracted_bydate" ] || [ "$DIR_NAME" = "extracted_by_date" ]; then
+    echo "$(getDirectory 'extracted')/By_Date"
+    ##
+  elif [ "$DIR_NAME" = "shifted_audio" ] || [ "$DIR_NAME" = "shifted_dir" ]; then
+    echo "$(getDirectory 'home')/BirdSongs/Extracted/By_Date/shifted"
+    ##
+  elif [ "$DIR_NAME" = "database" ]; then
+    #		 NOT USED
+    echo "$(getDirectory 'birdnet_pi')/database"
+    ##
+  elif [ "$DIR_NAME" = "config" ]; then
+    #		 NOT USED
+    echo "$(getDirectory 'birdnet_pi')/config"
+    ##
+  elif [ "$DIR_NAME" = "models" ] || [ "$DIR_NAME" = "model" ]; then
+    echo "$(getDirectory 'birdnet_pi')/model"
+    ##
+  elif [ "$DIR_NAME" = "python3_ve" ]; then
+    echo "$(getDirectory 'birdnet_pi')/birdnet/bin"
+    ##
+  elif [ "$DIR_NAME" = "scripts" ]; then
+    echo "$(getDirectory 'birdnet_pi')/scripts"
+    ##
+  elif [ "$DIR_NAME" = "stream_data" ]; then
+    echo "$(getDirectory 'recs_dir')/StreamData"
+    ##
+  elif [ "$DIR_NAME" = "templates" ]; then
+    echo "$(getDirectory 'birdnet_pi')/templates"
+    ##
+  elif [ "$DIR_NAME" = "web" ] || [ "$DIR_NAME" = "www" ]; then
+    echo "$(getDirectory 'birdnet_pi')/homepage"
+    ##
+  else
+    echo
+  fi
+}
+
+getFilePath() {
+  FILENAME=$1
+
+  if [ "$FILENAME" = "analyzing_now.txt" ]; then
+    echo "$(getDirectory 'birdnet_pi')/analyzing_now.txt"
+    ##
+  elif [ "$FILENAME" = "apprise.txt" ]; then
+    echo "$(getDirectory 'birdnet_pi')/apprise.txt"
+    ##
+  elif [ "$FILENAME" = "birdnet.conf" ]; then
+    echo "$(getDirectory 'birdnet_pi')/birdnet.conf"
+    ##
+  elif [ "$FILENAME" = "etc_birdnet.conf" ]; then
+    echo "/etc/birdnet/birdnet.conf"
+    ##
+  elif [ "$FILENAME" = "BirdDB.txt" ]; then
+    echo "$(getDirectory 'birdnet_pi')/BirdDB.txt"
+    ##
+  elif [ "$FILENAME" = "birds.db" ]; then
+    echo "$(getDirectory 'scripts')/birds.db"
+    ##
+  elif [ "$FILENAME" = "blacklisted_images.txt" ]; then
+    echo "$(getDirectory 'scripts')/blacklisted_images.txt"
+    ##
+  elif [ "$FILENAME" = "disk_check_exclude.txt" ]; then
+    echo "$(getDirectory 'scripts')/disk_check_exclude.txt"
+    ##
+  elif [ "$FILENAME" = "email_template" ]; then
+    echo "$(getDirectory 'scripts')/email_template"
+    ##
+  elif [ "$FILENAME" = "email_template2" ]; then
+    echo "$(getDirectory 'scripts')/email_template2"
+    ##
+  elif [ "$FILENAME" = "exclude_species_list.txt" ]; then
+    echo "$(getDirectory 'scripts')/exclude_species_list.txt"
+    ##
+  elif [ "$FILENAME" = "firstrun.ini" ]; then
+    echo "$(getDirectory 'birdnet_pi')/firstrun.ini"
+    ##
+  elif [ "$FILENAME" = ".gotty" ]; then
+    echo "$(getDirectory 'home')/.gotty"
+  ##
+  elif [ "$FILENAME" = "HUMAN.txt" ]; then
+    echo "$(getDirectory 'birdnet_pi')/HUMAN.txt"
+    ##
+  elif [ "$FILENAME" = "IdentifiedSoFar.txt" ] || [ "$FILENAME" = "IDFILE" ]; then
+    id_home_dir=$(getDirectory 'home')
+    echo "${IDFILE//$EXPANDED_HOME/$id_home_dir}"
+  ##
+  elif [ "$FILENAME" = "include_species_list.txt" ]; then
+    echo "$(getDirectory 'scripts')/include_species_list.txt"
+    ##
+  elif [ "$FILENAME" = "labels.txt" ] || [ "$FILENAME" = "labels.txt.old" ]; then
+    echo "$(getDirectory 'model')/$FILENAME"
+    ##
+  elif [ "$FILENAME" = "labels_flickr.txt" ]; then
+    echo "$(getDirectory 'model')/labels_flickr.txt"
+    ##
+  elif [ "$FILENAME" = "labels_l18n.zip" ]; then
+    echo "$(getDirectory 'model')/labels_l18n.zip"
+    ##
+  elif [ "$FILENAME" = "labels_lang.txt" ]; then
+    echo "$(getDirectory 'model')/labels_lang.txt"
+    ##
+  elif [ "$FILENAME" = "labels_nm.zip" ]; then
+    echo "$(getDirectory 'model')/labels_nm.zip"
+    ##
+  elif [ "$FILENAME" = "lastrun.txt" ]; then
+    echo "$(getDirectory 'scripts')/lastrun.txt"
+    ##
+  elif [ "$FILENAME" = "python3" ]; then
+    echo "$(getDirectory 'python3_ve')/python3 "
+    ##
+  elif [ "$FILENAME" = "python3_appraise" ]; then
+    echo "$(getDirectory 'python3_ve')/apprise "
+    ##
+  elif [ "$FILENAME" = "species.py" ]; then
+    echo "$(getDirectory 'scripts')/species.py"
+    ##
+  elif [ "$FILENAME" = "thisrun.txt" ]; then
+    echo "$(getDirectory 'scripts')/thisrun.txt"
+    ##
+  else
+    echo
+  fi
+}

--- a/scripts/createdb.sh
+++ b/scripts/createdb.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/common.sh
+
+BIRDS_DB="$(getFilePath 'birds.db')"
+
 source /etc/birdnet/birdnet.conf
-sqlite3 $HOME/BirdNET-Pi/scripts/birds.db << EOF
+sqlite3 $BIRDS_DB << EOF
 DROP TABLE IF EXISTS detections;
 CREATE TABLE IF NOT EXISTS detections (
   Date DATE,
@@ -18,5 +23,5 @@ CREATE TABLE IF NOT EXISTS detections (
 CREATE INDEX "detections_Com_Name" ON "detections" ("Com_Name");
 CREATE INDEX "detections_Date_Time" ON "detections" ("Date" DESC, "Time" DESC);
 EOF
-chown $USER:$USER $HOME/BirdNET-Pi/scripts/birds.db
-chmod g+w $HOME/BirdNET-Pi/scripts/birds.db
+chown $USER:$USER $BIRDS_DB
+chmod g+w $BIRDS_DB

--- a/scripts/custom_recording.sh
+++ b/scripts/custom_recording.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
-set -x
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/common.sh
+
 source /etc/birdnet/birdnet.conf
+#set -x
+
+EXTRACTED_DIR="$(getDirectory 'extracted')"
 
 STAMP="%H:%M:%S"
 
@@ -20,12 +25,12 @@ while [ $now -ge ${CUSTOM_WINDOW_START[0]} ] && [ $now -le ${CUSTOM_WINDOW_END[0
   # If you prefer no directory structure under "Raw", comment out the
   # lines below and uncommend the commands at the bottom.
   arecord -f S16_LE -c${CHANNELS} -r48000 -t wav -d $RECORDING_DURATION \
-    --use-strftime ${EXTRACTED}/Raw/%B-%Y/%d-%A/%F-birdnet-${STAMP}.wav
+    --use-strftime ${EXTRACTED_DIR}/Raw/%B-%Y/%d-%A/%F-birdnet-${STAMP}.wav
   
   # Uncomment the lines below if you'd prefer having no directory scructure
   # under the "Raw" directory. Be sure to comment out the command above.
   #arecord -f S16_LE -c${CHANNELS} -r48000 -t wav -d $RECORDING_DURATION \
-  #  --use-strftime ${EXTRACTED}/Raw/%F-birdnet-${STAMP}.wav
+  #  --use-strftime ${EXTRACTED_DIR}/Raw/%F-birdnet-${STAMP}.wav
   sleep $PAUSE_DURATION
   now=$(date +%H)
 done
@@ -34,12 +39,12 @@ while [ $now -ge ${CUSTOM_WINDOW_START[1]} ] && [ $now -le ${CUSTOM_WINDOW_END[1
   # If you prefer no directory structure under "Raw", comment out the
   # lines below and uncommend the commands at the bottom.
   arecord -f S16_LE -c${CHANNELS} -r48000 -t wav -d $RECORDING_DURATION \
-    --use-strftime ${EXTRACTED}/Raw/%B-%Y/%d-%A/%F-birdnet-${STAMP}.wav
+    --use-strftime ${EXTRACTED_DIR}/Raw/%B-%Y/%d-%A/%F-birdnet-${STAMP}.wav
   
   # Uncomment the lines below if you'd prefer having no directory scructure
   # under the "Raw" directory. Be sure to comment out the command above.
   #arecord -f S16_LE -c${CHANNELS} -r48000 -t wav -d $RECORDING_DURATION \
-  #  --use-strftime ${EXTRACTED}/Raw/%F-birdnet-${STAMP}.wav
+  #  --use-strftime ${EXTRACTED_DIR}/Raw/%F-birdnet-${STAMP}.wav
   sleep $PAUSE_DURATION
   now=$(date +%H)
 done
@@ -48,12 +53,12 @@ while [ $now -ge ${CUSTOM_WINDOW_START[2]} ] && [ $now -le ${CUSTOM_WINDOW_END[2
   # If you prefer no directory structure under "Raw", comment out the
   # lines below and uncommend the commands at the bottom.
   arecord -f S16_LE -c${CHANNELS} -r48000 -t wav -d $RECORDING_DURATION \
-    --use-strftime ${EXTRACTED}/Raw/%B-%Y/%d-%A/%F-birdnet-${STAMP}.wav
+    --use-strftime ${EXTRACTED_DIR}/Raw/%B-%Y/%d-%A/%F-birdnet-${STAMP}.wav
   
   # Uncomment the lines below if you'd prefer having no directory scructure
   # under the "Raw" directory. Be sure to comment out the command above.
   #arecord -f S16_LE -c${CHANNELS} -r48000 -t wav -d $RECORDING_DURATION \
-  #  --use-strftime ${EXTRACTED}/Raw/%F-birdnet-${STAMP}.wav 
+  #  --use-strftime ${EXTRACTED_DIR}/Raw/%F-birdnet-${STAMP}.wav 
   sleep $PAUSE_DURATION
   now=$(date +%H)
 done
@@ -62,12 +67,12 @@ while [ $now -ge ${CUSTOM_WINDOW_START[3]} ] && [ $now -le ${CUSTOM_WINDOW_END[3
   # If you prefer no directory structure under "Raw", comment out the
   # lines below and uncommend the commands at the bottom.
   arecord -f S16_LE -c${CHANNELS} -r48000 -t wav -d $RECORDING_DURATION \
-    --use-strftime ${EXTRACTED}/Raw/%B-%Y/%d-%A/%F-birdnet-${STAMP}.wav
+    --use-strftime ${EXTRACTED_DIR}/Raw/%B-%Y/%d-%A/%F-birdnet-${STAMP}.wav
   
   # Uncomment the lines below if you'd prefer having no directory scructure
   # under the "Raw" directory. Be sure to comment out the command above.
   #arecord -f S16_LE -c${CHANNELS} -r48000 -t wav -d $RECORDING_DURATION \
-  #  --use-strftime ${EXTRACTED}/Raw/%F-birdnet-${STAMP}.wav
+  #  --use-strftime ${EXTRACTED_DIR}/Raw/%F-birdnet-${STAMP}.wav
   sleep $PAUSE_DURATION
   now=$(date +%H)
 done

--- a/scripts/disk_check.sh
+++ b/scripts/disk_check.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/common.sh
+
+EXTRACTED_DIR="$(getDirectory 'extracted')"
+PROCESSED_DIR="$(getDirectory 'processed')"
+
 set -x
 used="$(df -h / | tail -n1 | awk '{print $5}')"
 
@@ -7,26 +13,27 @@ if [ "${used//%}" -ge 95 ]; then
 
   case $FULL_DISK in
     purge) echo "Removing oldest data"
-        cd ${EXTRACTED}/By_Date/
+        # shellcheck disable=SC2164
+        cd ${EXTRACTED_DIR}/By_Date/
         curl localhost/views.php?view=Species%20Stats &>/dev/null
-        if ! grep -qxFe \#\#start $HOME/BirdNET-Pi/scripts/disk_check_exclude.txt; then
+        if ! grep -qxFe \#\#start "$(getFilePath 'disk_check_exclude.txt')"; then
             exit
         fi
-        filestodelete=$(($(find ${EXTRACTED}/By_Date/* -type f | wc -l) / $(find ${EXTRACTED}/By_Date/* -maxdepth 0 -type d | wc -l)))
+        filestodelete=$(($(find ${EXTRACTED_DIR}/By_Date/* -type f | wc -l) / $(find ${EXTRACTED_DIR}/By_Date/* -maxdepth 0 -type d | wc -l)))
         iter=0
         for i in */*/*; do
             if [ $iter -ge $filestodelete ]; then
                 break
             fi
-            if ! grep -qxFe "$i" $HOME/BirdNET-Pi/scripts/disk_check_exclude.txt; then
+            if ! grep -qxFe "$i" "$(getFilePath 'disk_check_exclude.txt')"; then
                 rm "$i"
             fi
             ((iter++))
         done
         find ~/BirdSongs/ -type d -empty -mtime +90 -delete
-        find ${EXTRACTED}/By_Date/ -empty -type d -delete;;
+        find ${EXTRACTED_DIR}/By_Date/ -empty -type d -delete;;
 
-       #rm -drfv "$(find ${EXTRACTED}/By_Date/* -maxdepth 1 -type d -prune \
+       #rm -drfv "$(find ${EXTRACTED_DIR}/By_Date/* -maxdepth 1 -type d -prune \
         # | sort -r | tail -n1)";;
     keep) echo "Stopping Core Services"
        /usr/local/bin/stop_core_services.sh;;
@@ -36,7 +43,7 @@ sleep 1
 if [ "${used//%}" -ge 95 ]; then
   case $FULL_DISK in
     purge) echo "Removing more data"
-       rm -rfv ${PROCESSED}/*;;
+       rm -rfv ${PROCESSED_DIR}/*;;
     keep) echo "Stopping Core Services"
        /usr/local/bin/stop_core_services.sh;;
   esac

--- a/scripts/disk_check.sh
+++ b/scripts/disk_check.sh
@@ -4,6 +4,8 @@ BINDIR=$(cd $(dirname $0) && pwd)
 
 EXTRACTED_DIR="$(getDirectory 'extracted')"
 PROCESSED_DIR="$(getDirectory 'processed')"
+RECORDINGS_DIR="$(getDirectory 'recordings_dir')"
+disk_check_exclude_path=$(getFilePath 'disk_check_exclude.txt')
 
 set -x
 used="$(df -h / | tail -n1 | awk '{print $5}')"
@@ -16,7 +18,7 @@ if [ "${used//%}" -ge 95 ]; then
         # shellcheck disable=SC2164
         cd ${EXTRACTED_DIR}/By_Date/
         curl localhost/views.php?view=Species%20Stats &>/dev/null
-        if ! grep -qxFe \#\#start "$(getFilePath 'disk_check_exclude.txt')"; then
+        if ! grep -qxFe \#\#start "${disk_check_exclude_path}"; then
             exit
         fi
         filestodelete=$(($(find ${EXTRACTED_DIR}/By_Date/* -type f | wc -l) / $(find ${EXTRACTED_DIR}/By_Date/* -maxdepth 0 -type d | wc -l)))
@@ -25,12 +27,12 @@ if [ "${used//%}" -ge 95 ]; then
             if [ $iter -ge $filestodelete ]; then
                 break
             fi
-            if ! grep -qxFe "$i" "$(getFilePath 'disk_check_exclude.txt')"; then
+            if ! grep -qxFe "$i" "${disk_check_exclude_path}"; then
                 rm "$i"
             fi
             ((iter++))
         done
-        find ~/BirdSongs/ -type d -empty -mtime +90 -delete
+        find ${RECORDINGS_DIR} -type d -empty -mtime +90 -delete
         find ${EXTRACTED_DIR}/By_Date/ -empty -type d -delete;;
 
        #rm -drfv "$(find ${EXTRACTED_DIR}/By_Date/* -maxdepth 1 -type d -prune \

--- a/scripts/dump_logs.sh
+++ b/scripts/dump_logs.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/common.sh
+
+LOG_DIR="$(getDirectory 'birdnet_pi')/logs"
+my_dir="$(getDirectory 'scripts')"
+BIRDNET_PI_DIR="$(getDirectory 'birdnet_pi')"
+RECORDING_DIR="$(getDirectory 'recs_dir')"
+
 # A comprehensive log dumper
 # set -x # Uncomment to debug
 source /etc/birdnet/birdnet.conf &> /dev/null
-LOG_DIR="${HOME}/BirdNET-Pi/logs"
-my_dir=$HOME/BirdNET-Pi/scripts
 services=$(awk '/service/ && /systemctl/ && !/php/ {print $3}' ${my_dir}/install_services.sh | sort)
 
 # Create logs directory
@@ -18,7 +24,7 @@ for i in "${services[@]}";do
 done
 
 # Create password-removed birdnet.conf
-sed -e '/PWD=/d' ${HOME}/BirdNET-Pi/birdnet.conf > ${LOG_DIR}/birdnet.conf 
+sed -e '/PWD=/d' "$(getFilePath 'birdnet.conf')" > ${LOG_DIR}/birdnet.conf
 
 # Create password-removed Caddyfile
 if [ -f /etc/caddy/Caddyfile ];then
@@ -34,7 +40,7 @@ echo "SOUND_CARD=${SOUND_CARD}" > ${LOG_DIR}/soundcard
 script -c "arecord -D ${SOUND_CARD} --dump-hw-params" -a ${LOG_DIR}/soundcard &> /dev/null
 
 # Get system info
-CALLS=("df -h" "free -h" "ifconfig" "find ${RECS_DIR}")
+CALLS=("df -h" "free -h" "ifconfig" "find ${RECORDING_DIR}")
 
 for i in "${CALLS[@]}";do
   ${i} >> ${LOG_DIR}/sysinfo
@@ -46,6 +52,6 @@ for i in "${CALLS[@]}";do
 done
 
 # TAR the logs into a ball
-tar --remove-files -cvpzf ${HOME}/BirdNET-Pi/logs.tar.gz ${LOG_DIR} &> /dev/null
+tar --remove-files -cvpzf ${BIRDNET_PI_DIR}/logs.tar.gz ${LOG_DIR} &> /dev/null
 # Finished
-echo "Your compressed logs are located at ${HOME}/BirdNET-Pi/logs.tar.gz"
+echo "Your compressed logs are located at ${BIRDNET_PI_DIR}/logs.tar.gz"

--- a/scripts/install_language_label.sh
+++ b/scripts/install_language_label.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/common.sh
+
+MODEL_DIR="$(getDirectory 'model')"
+labels_l18n_zip_path="$(getFilePath 'labels_l18n.zip')"
+labels_txt_path="$(getFilePath 'labels.txt')"
+labels_flickr_path="$(getFilePath 'labels_flickr.txt')"
 
 usage() { echo "Usage: $0 -l <language i18n id>" 1>&2; exit 1; }
 
@@ -14,20 +21,20 @@ while getopts "l:" o; do
 done
 shift $((OPTIND-1))
 
-HOME=$(awk -F: '/1000/ {print $6}' /etc/passwd)
+#HOME=$(awk -F: '/1000/ {print $6}' /etc/passwd)
 
 label_file_name="labels_${lang}.txt"
 
-unzip -o $HOME/BirdNET-Pi/model/labels_l18n.zip $label_file_name \
-  -d $HOME/BirdNET-Pi/model \
-  && mv -f $HOME/BirdNET-Pi/model/$label_file_name $HOME/BirdNET-Pi/model/labels.txt \
+unzip -o $labels_l18n_zip_path $label_file_name \
+  -d $MODEL_DIR \
+  && mv -f $MODEL_DIR/$label_file_name $labels_txt_path \
   && logger "[$0] Changed language label file to '$label_file_name'";
 
 label_file_name_flickr="labels_en.txt"
 
-unzip -o $HOME/BirdNET-Pi/model/labels_l18n.zip $label_file_name_flickr \
-  -d $HOME/BirdNET-Pi/model \
-  && mv -f $HOME/BirdNET-Pi/model/$label_file_name_flickr $HOME/BirdNET-Pi/model/labels_flickr.txt \
+unzip -o $labels_l18n_zip_path $label_file_name_flickr \
+  -d $MODEL_DIR \
+  && mv -f $$MODEL_DIR/$label_file_name_flickr $labels_flickr_path \
   && logger "[$0] Set Flickr labels '$label_file_name_flickr'";
 
 exit 0

--- a/scripts/install_language_label_nm.sh
+++ b/scripts/install_language_label_nm.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/common.sh
+
+MODEL_DIR="$(getDirectory 'model')"
+labels_nm_zip_path="$(getFilePath 'labels_nm.zip')"
+labels_txt_path="$(getFilePath 'labels.txt')"
+labels_flickr_path="$(getFilePath 'labels_flickr.txt')"
 
 usage() { echo "Usage: $0 -l <language i18n id>" 1>&2; exit 1; }
 
@@ -14,20 +21,20 @@ while getopts "l:" o; do
 done
 shift $((OPTIND-1))
 
-HOME=$(awk -F: '/1000/ {print $6}' /etc/passwd)
+#HOME=$(awk -F: '/1000/ {print $6}' /etc/passwd)
 
 label_file_name="labels_${lang}.txt"
 
-unzip -o $HOME/BirdNET-Pi/model/labels_nm.zip $label_file_name \
-  -d $HOME/BirdNET-Pi/model \
-  && mv -f $HOME/BirdNET-Pi/model/$label_file_name $HOME/BirdNET-Pi/model/labels.txt \
+unzip -o $labels_nm_zip_path $label_file_name \
+  -d $MODEL_DIR \
+  && mv -f $MODEL_DIR/$label_file_name $labels_txt_path \
   && logger "[$0] Changed language label file to '$label_file_name'";
 
 label_file_name_flickr="labels_en.txt"
 
-unzip -o $HOME/BirdNET-Pi/model/labels_nm.zip $label_file_name_flickr \
-  -d $HOME/BirdNET-Pi/model \
-  && mv -f $HOME/BirdNET-Pi/model/$label_file_name_flickr $HOME/BirdNET-Pi/model/labels_flickr.txt \
+unzip -o $labels_nm_zip_path $label_file_name_flickr \
+  -d $MODEL_DIR \
+  && mv -f $MODEL_DIR/$label_file_name_flickr $labels_flickr_path \
   && logger "[$0] Set Flickr labels '$label_file_name_flickr'";
 
 exit 0

--- a/scripts/most_recent.sh
+++ b/scripts/most_recent.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/common.sh
+
+BIRDS_DB_PATH="$(getFilePath 'birds.db')"
+
 OLDIFS=$IFS
 IFS=\|
-most_recent_results=($(sqlite3 ~/BirdNET-Pi/scripts/birds.db \
+most_recent_results=($(sqlite3 "$BIRDS_DB_PATH" \
   'SELECT Com_Name, Time, Date FROM detections
    ORDER BY Date DESC, Time DESC
    LIMIT 1'))

--- a/scripts/restart_services.sh
+++ b/scripts/restart_services.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/common.sh
+
 # Restarts ALL services and removes ALL unprocessed audio
 source /etc/birdnet/birdnet.conf
-set -x
-my_dir=$HOME/BirdNET-Pi/scripts
+SCRIPTS_DIR="$(getDirectory 'scripts')"
 
+# Raise script debug flag
+set -x
 
 sudo systemctl stop birdnet_server.service
 sudo systemctl stop birdnet_recording.service

--- a/scripts/spectrogram.sh
+++ b/scripts/spectrogram.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/common.sh
+
+analyzing_now_txt_path="$(getFilePath 'analyzing_now.txt')"
+HOME_DIR="$(getDirectory 'home')"
+EXTRACTED_DIR="$(getDirectory 'extracted')"
+
 # Make sox spectrogram
 source /etc/birdnet/birdnet.conf
 
@@ -18,11 +25,11 @@ SLEEP_DELAY=$((RECORDING_LENGTH / 4))
 
 # Continuously loop generating a spectrogram every 10 seconds
 while true; do
-  analyzing_now="$(cat $HOME/BirdNET-Pi/analyzing_now.txt)"
+  analyzing_now="$(cat $analyzing_now_txt_path)"
 
   if [ ! -z "${analyzing_now}" ] && [ -f "${analyzing_now}" ]; then
-    spectrogram_png=${EXTRACTED}/spectrogram.png
-    sox -V1 "${analyzing_now}" -n remix 1 rate 24k spectrogram -c "${analyzing_now//$HOME\//}" -o "${spectrogram_png}"
+    spectrogram_png=${EXTRACTED_DIR}/spectrogram.png
+    sox -V1 "${analyzing_now}" -n remix 1 rate 24k spectrogram -c "${analyzing_now//$HOME_DIR\//}" -o "${spectrogram_png}"
   fi
 
   sleep $SLEEP_DELAY

--- a/scripts/stop_core_services.sh
+++ b/scripts/stop_core_services.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-# Restarts ALL services and removes ALL unprocessed audio
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/common.sh
 
+RECORDINGS_DIRECTORY="$(getDirectory 'recordings_dir')"
 
+# Stops ALL services and removes ALL unprocessed audio
 services=(birdnet_recording.service
 custom_recording.service
 birdnet_analysis.service
@@ -13,4 +16,4 @@ spectrogram_viewer.service)
 for i in  "${services[@]}";do
   sudo systemctl stop  ${i}
 done
-sudo rm -rf ${RECS_DIR}/$(date +%B-%Y/%d-%A)/*
+sudo rm -rf "${RECORDINGS_DIRECTORY}"/$(date +%B-%Y/%d-%A)/*

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/common.sh
+
+gotty_path="$(getFilePath '.gotty')"
+birdnet_conf_path="$(getFilePath 'birdnet.conf')"
+SCRIPTS_DIR="$(getDirectory 'scripts')"
+BIRDNETPI_DIR="$(getDirectory 'birdnet_pi')"
+
 # Uninstall script to remove everything
 #set -x # Uncomment to debug
 trap 'rm -f ${TMPFILE}' EXIT
-my_dir=$HOME/BirdNET-Pi/scripts
-source /etc/birdnet/birdnet.conf &> /dev/null
-SCRIPTS=($(ls -1 ${my_dir}) ${HOME}/.gotty)
+SCRIPTS=($(ls -1 ${SCRIPTS_DIR}) ${gotty_path})
 set -x
-services=($(awk '/service/ && /systemctl/ && !/php/ {print $3}' ${my_dir}/install_services.sh | sort) custom_recording.service avahi-alias@.service)
+services=($(awk '/service/ && /systemctl/ && !/php/ {print $3}' ${SCRIPTS_DIR}/install_services.sh | sort) custom_recording.service avahi-alias@.service)
 
 remove_services() {
   for i in "${services[@]}"; do
@@ -50,5 +56,5 @@ remove_scripts() {
 remove_services
 remove_scripts
 if [ -d /etc/birdnet ];then sudo rm -drf /etc/birdnet;fi
-if [ -f ${HOME}/BirdNET-Pi/birdnet.conf ];then sudo rm -f ${HOME}/BirdNET-Pi/birdnet.conf;fi
-echo "Uninstall finished. Remove this directory with 'rm -drfv' to finish."
+if [ -f "${birdnet_conf_path}" ];then sudo rm -f "${birdnet_conf_path}";fi
+echo "Uninstall finished. Remove this directory with 'rm -drfv ${BIRDNETPI_DIR}' to finish."

--- a/scripts/update_birdnet.sh
+++ b/scripts/update_birdnet.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/common.sh
+
+SCRIPTS_DIR="$(getDirectory 'scripts')"
+BIRDNET_PI_DIR="$(getDirectory 'birdnet_pi')"
+
 # Update BirdNET-Pi's Git Repo
 source /etc/birdnet/birdnet.conf
 trap 'exit 1' SIGINT SIGHUP
 
 usage() { echo "Usage: $0 [-r <remote name>] [-b <branch name>]" 1>&2; exit 1; }
-
-USER=$(awk -F: '/1000/ {print $1}' /etc/passwd)
-HOME=$(awk -F: '/1000/ {print $6}' /etc/passwd)
-my_dir=$HOME/BirdNET-Pi/scripts
 
 # Defaults
 remote="origin"
@@ -17,7 +19,7 @@ while getopts ":r:b:" o; do
   case "${o}" in
     r)
       remote=${OPTARG}
-      git -C $HOME/BirdNET-Pi remote show $remote > /dev/null 2>&1
+      git -C "$BIRDNET_PI_DIR" remote show $remote > /dev/null 2>&1
       ret_val=$?
 
       if [ $ret_val -ne 0 ]; then
@@ -42,23 +44,23 @@ sudo_with_user () {
 }
 
 # Get current HEAD hash
-commit_hash=$(sudo_with_user git -C $HOME/BirdNET-Pi rev-parse HEAD)
+commit_hash=$(sudo_with_user git -C "$BIRDNET_PI_DIR" rev-parse HEAD)
 
 # Reset current HEAD to remove any local changes
-sudo_with_user git -C $HOME/BirdNET-Pi reset --hard
+sudo_with_user git -C "$BIRDNET_PI_DIR" reset --hard
 
 # Fetches latest changes
-sudo_with_user git -C $HOME/BirdNET-Pi fetch $remote $branch
+sudo_with_user git -C "$BIRDNET_PI_DIR" fetch $remote $branch
 
 # Switches git to specified branch
-sudo_with_user git -C $HOME/BirdNET-Pi switch -C $branch --track $remote/$branch
+sudo_with_user git -C "$BIRDNET_PI_DIR" switch -C $branch --track $remote/$branch
 
 # Prints out changes
-sudo_with_user git -C $HOME/BirdNET-Pi diff --stat $commit_hash HEAD
+sudo_with_user git -C "$BIRDNET_PI_DIR" diff --stat $commit_hash HEAD
 
 sudo systemctl daemon-reload
-sudo ln -sf $my_dir/* /usr/local/bin/
+sudo ln -sf $SCRIPTS_DIR/* /usr/local/bin/
 
 # The script below handles changes to the host system
 # Any additions to the updater should be placed in that file.
-sudo $my_dir/update_birdnet_snippets.sh
+sudo $SCRIPTS_DIR/update_birdnet_snippets.sh

--- a/scripts/update_birdnet_snippets.sh
+++ b/scripts/update_birdnet_snippets.sh
@@ -248,9 +248,6 @@ if grep -q '^MODEL=BirdNET_GLOBAL_3K_V2.2_Model_FP16$' "$etc_birdnet_conf_path";
   sudo chmod +x "$SCRIPTS_DIR"/install_language_label_nm.sh && "$SCRIPTS_DIR"/install_language_label_nm.sh -l "$language"
 fi
 
-# Link in new bash script common.sh to local/bin
-ln -sf ${SCRIPTS_DIR}/common.sh /usr/local/bin/
-
 # Symlink the new config directory into the Extracted & Local Bin directory
 [ -L ~/BirdSongs/Extracted/config ] || ln -sf ~/BirdNET-Pi/config ~/BirdSongs/Extracted
 [ -L /usr/local/bin/config ] || ln -sf ~/BirdNET-Pi/config /usr/local/bin/
@@ -259,6 +256,9 @@ if ! which jq &>/dev/null;then
   sudo apt update && sudo apt -y install jq
 fi
 
+# Link in new bash script common.sh to local/bin and make sure the config directory is also
+[ -L /usr/local/bin/common.sh ] || ln -sf ${SCRIPTS_DIR}/common.sh /usr/local/bin/
+[ -L /usr/local/bin/config ] || ln -sf ${BIRDNET_PI_DIR}/config /usr/local/bin/
 
 sudo systemctl daemon-reload
 restart_services.sh

--- a/scripts/update_birdnet_snippets.sh
+++ b/scripts/update_birdnet_snippets.sh
@@ -1,232 +1,251 @@
 #!/usr/bin/env bash
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/common.sh
+
+SCRIPTS_DIR="$(getDirectory 'scripts')"
+apprise_txt_path="$(getFilePath 'apprise.txt')"
+birds_db_path="$(getFilePath 'birds.db')"
+etc_birdnet_conf_path="$(getFilePath 'etc_birdnet.conf')"
+birdnet_conf_path="$(getFilePath 'birdnet.conf')"
+labels_txt_path="$(getFilePath 'labels.txt')"
+labels_txt_old_path="$(getFilePath 'labels.txt.old')"
+python3_exec_path="$(getFilePath 'python3')"
+thisrun_txt_path="$(getFilePath 'thisrun.txt')"
+
+HOME_DIR="$(getDirectory 'home')"
+BIRDNET_PI_DIR="$(getDirectory 'birdnet_pi')"
+EXTRACTED_DIR="$(getDirectory 'extracted')"
+TEMPLATES_DIR="$(getDirectory 'templates')"
+PYTHON3_VE_DIR="$(getDirectory 'python3_ve')"
+WWW_HOMEPAGE_DIR="$(getDirectory 'web')"
+
 # Update BirdNET-Pi
 source /etc/birdnet/birdnet.conf
 trap 'exit 1' SIGINT SIGHUP
 USER=$(awk -F: '/1000/ {print $1}' /etc/passwd)
 HOME=$(awk -F: '/1000/ {print $6}' /etc/passwd)
-my_dir=$HOME/BirdNET-Pi/scripts
 
 # Sets proper permissions and ownership
 #sudo -E chown -R $USER:$USER $HOME/*
 #sudo chmod -R g+wr $HOME/*
-find $HOME/Bird* -type f ! -perm -g+wr -exec chmod g+wr {} + 2>/dev/null
-find $HOME/Bird* -not -user $USER -execdir sudo -E chown $USER:$USER {} \+
-chmod 666 ~/BirdNET-Pi/scripts/*.txt
-chmod 666 ~/BirdNET-Pi/*.txt
-find $HOME/BirdNET-Pi -path "$HOME/BirdNET-Pi/birdnet" -prune -o -type f ! -perm /o=w -exec chmod a+w {} \;
+find $HOME_DIR/Bird* -type f ! -perm -g+wr -exec chmod g+wr {} + 2>/dev/null
+find $HOME_DIR/Bird* -not -user $USER -execdir sudo -E chown $USER:$USER {} \+
+chmod 666 "$SCRIPTS_DIR"/*.txt
+chmod 666 "$BIRDNET_PI_DIR"/*.txt
+find $BIRDNET_PI_DIR -path "$BIRDNET_PI_DIR/birdnet" -prune -o -type f ! -perm /o=w -exec chmod a+w {} \;
 
 # remove world-writable perms
-chmod -R o-w ~/BirdNET-Pi/templates/*
+chmod -R o-w $TEMPLATES_DIR/*
 
 
 # Create blank sitename as it's optional. First time install will use $HOSTNAME.
-if ! grep SITE_NAME /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "SITE_NAME=\"\"" >> /etc/birdnet/birdnet.conf
+if ! grep SITE_NAME "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "SITE_NAME=\"\"" >> "$etc_birdnet_conf_path"
 fi
 
-if ! grep PRIVACY_THRESHOLD /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "PRIVACY_THRESHOLD=0" >> /etc/birdnet/birdnet.conf
-  git -C $HOME/BirdNET-Pi rm $my_dir/privacy_server.py
+if ! grep PRIVACY_THRESHOLD "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "PRIVACY_THRESHOLD=0" >> "$etc_birdnet_conf_path"
+  git -C "$BIRDNET_PI_DIR" rm $SCRIPTS_DIR/privacy_server.py
 fi
-if [ -f $my_dir/privacy_server ] || [ -L /usr/local/bin/privacy_server.py ];then
-  rm -f $my_dir/privacy_server.py
+if [ -f $SCRIPTS_DIR/privacy_server ] || [ -L /usr/local/bin/privacy_server.py ];then
+  rm -f $SCRIPTS_DIR/privacy_server.py
   rm -f /usr/local/bin/privacy_server.py
 fi
 
 # Adds python virtual-env to the python systemd services
-if ! grep 'BirdNET-Pi/birdnet/' $HOME/BirdNET-Pi/templates/birdnet_server.service &>/dev/null || ! grep 'BirdNET-Pi/birdnet' $HOME/BirdNET-Pi/templates/chart_viewer.service &>/dev/null;then
-  sudo -E sed -i "s|ExecStart=.*|ExecStart=$HOME/BirdNET-Pi/birdnet/bin/python3 /usr/local/bin/server.py|" ~/BirdNET-Pi/templates/birdnet_server.service
-  sudo -E sed -i "s|ExecStart=.*|ExecStart=$HOME/BirdNET-Pi/birdnet/bin/python3 /usr/local/bin/daily_plot.py|" ~/BirdNET-Pi/templates/chart_viewer.service
+if ! grep 'BirdNET-Pi/birdnet/' $TEMPLATES_DIR/birdnet_server.service &>/dev/null || ! grep 'BirdNET-Pi/birdnet' $TEMPLATES_DIR/chart_viewer.service &>/dev/null;then
+  sudo -E sed -i "s|ExecStart=.*|ExecStart=$python3_exec_path /usr/local/bin/server.py|" $TEMPLATES_DIR/birdnet_server.service
+  sudo -E sed -i "s|ExecStart=.*|ExecStart=$python3_exec_path /usr/local/bin/daily_plot.py|" $TEMPLATES_DIR/chart_viewer.service
   sudo systemctl daemon-reload && restart_services.sh
 fi
 
-if grep privacy ~/BirdNET-Pi/templates/birdnet_server.service &>/dev/null;then
+if grep privacy $TEMPLATES_DIR/birdnet_server.service &>/dev/null;then
   sudo -E sed -i 's/privacy_server.py/server.py/g' \
-    ~/BirdNET-Pi/templates/birdnet_server.service
+    $TEMPLATES_DIR/birdnet_server.service
   sudo systemctl daemon-reload
   restart_services.sh
 fi
-if ! grep APPRISE_NOTIFICATION_TITLE /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "APPRISE_NOTIFICATION_TITLE=\"New BirdNET-Pi Detection\"" >> /etc/birdnet/birdnet.conf
+if ! grep APPRISE_NOTIFICATION_TITLE "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "APPRISE_NOTIFICATION_TITLE=\"New BirdNET-Pi Detection\"" >> "$etc_birdnet_conf_path"
 fi
-if ! grep APPRISE_NOTIFICATION_BODY /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "APPRISE_NOTIFICATION_BODY=\"A \$sciname \$comname was just detected with a confidence of \$confidence\"" >> /etc/birdnet/birdnet.conf
+if ! grep APPRISE_NOTIFICATION_BODY "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "APPRISE_NOTIFICATION_BODY=\"A \$sciname \$comname was just detected with a confidence of \$confidence\"" >> "$etc_birdnet_conf_path"
 fi
-if ! grep APPRISE_NOTIFY_EACH_DETECTION /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "APPRISE_NOTIFY_EACH_DETECTION=0 " >> /etc/birdnet/birdnet.conf
+if ! grep APPRISE_NOTIFY_EACH_DETECTION "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "APPRISE_NOTIFY_EACH_DETECTION=0 " >> "$etc_birdnet_conf_path"
 fi
-if ! grep APPRISE_NOTIFY_NEW_SPECIES /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "APPRISE_NOTIFY_NEW_SPECIES=0 " >> /etc/birdnet/birdnet.conf
+if ! grep APPRISE_NOTIFY_NEW_SPECIES "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "APPRISE_NOTIFY_NEW_SPECIES=0 " >> "$etc_birdnet_conf_path"
 fi
-if ! grep APPRISE_NOTIFY_NEW_SPECIES_EACH_DAY /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "APPRISE_NOTIFY_NEW_SPECIES_EACH_DAY=0 " >> /etc/birdnet/birdnet.conf
+if ! grep APPRISE_NOTIFY_NEW_SPECIES_EACH_DAY "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "APPRISE_NOTIFY_NEW_SPECIES_EACH_DAY=0 " >> "$etc_birdnet_conf_path"
 fi
-if ! grep APPRISE_MINIMUM_SECONDS_BETWEEN_NOTIFICATIONS_PER_SPECIES /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "APPRISE_MINIMUM_SECONDS_BETWEEN_NOTIFICATIONS_PER_SPECIES=0 " >> /etc/birdnet/birdnet.conf
+if ! grep APPRISE_MINIMUM_SECONDS_BETWEEN_NOTIFICATIONS_PER_SPECIES "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "APPRISE_MINIMUM_SECONDS_BETWEEN_NOTIFICATIONS_PER_SPECIES=0 " >> "$etc_birdnet_conf_path"
 fi
 
 # If the config does not contain the DATABASE_LANG setting, we'll want to add it.
 # Defaults to not-selected, which config.php will know to render as a language option.
 # The user can then select a language in the web interface and update with that.
-if ! grep DATABASE_LANG /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "DATABASE_LANG=not-selected" >> /etc/birdnet/birdnet.conf
+if ! grep DATABASE_LANG "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "DATABASE_LANG=not-selected" >> "$etc_birdnet_conf_path"
 fi
 
-apprise_installation_status=$(~/BirdNET-Pi/birdnet/bin/python3 -c 'import pkgutil; print("installed" if pkgutil.find_loader("apprise") else "not installed")')
+apprise_installation_status=$($python3_exec_path -c 'import pkgutil; print("installed" if pkgutil.find_loader("apprise") else "not installed")')
 if [[ "$apprise_installation_status" = "not installed" ]];then
-  $HOME/BirdNET-Pi/birdnet/bin/pip3 install -U pip
-  $HOME/BirdNET-Pi/birdnet/bin/pip3 install apprise==1.2.1
+  $PYTHON3_VE_DIR/pip3 install -U pip
+  $PYTHON3_VE_DIR/pip3 install apprise==1.2.1
 fi
-[ -f $HOME/BirdNET-Pi/apprise.txt ] || sudo -E -ucaddy touch $HOME/BirdNET-Pi/apprise.txt
+[ -f $apprise_txt_path ] || sudo -E -ucaddy touch $apprise_txt_path
 if ! which lsof &>/dev/null;then
   sudo apt update && sudo apt -y install lsof
 fi
-if ! grep RTSP_STREAM /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "RTSP_STREAM=" >> /etc/birdnet/birdnet.conf
+if ! grep RTSP_STREAM "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "RTSP_STREAM=" >> "$etc_birdnet_conf_path"
 fi
-if grep bash $HOME/BirdNET-Pi/templates/web_terminal.service &>/dev/null;then
-  sudo sed -i '/User/d;s/bash/login/g' $HOME/BirdNET-Pi/templates/web_terminal.service
+if grep bash $TEMPLATES_DIR/web_terminal.service &>/dev/null;then
+  sudo sed -i '/User/d;s/bash/login/g' $TEMPLATES_DIR/web_terminal.service
   sudo systemctl daemon-reload
   sudo systemctl restart web_terminal.service
 fi
-[ -L ~/BirdSongs/Extracted/static ] || ln -sf ~/BirdNET-Pi/homepage/static ~/BirdSongs/Extracted
-if ! grep FLICKR_API_KEY /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "FLICKR_API_KEY=" >> /etc/birdnet/birdnet.conf
+[ -L $EXTRACTED_DIR/static ] || ln -sf $WWW_HOMEPAGE_DIR/static $EXTRACTED_DIR
+if ! grep FLICKR_API_KEY "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "FLICKR_API_KEY=" >> "$etc_birdnet_conf_path"
 fi
 if systemctl list-unit-files pushed_notifications.service &>/dev/null;then
   sudo systemctl disable --now pushed_notifications.service
   sudo rm -f /usr/lib/systemd/system/pushed_notifications.service
-  sudo rm $HOME/BirdNET-Pi/templates/pushed_notifications.service
+  sudo rm $TEMPLATES_DIR/pushed_notifications.service
 fi
 
-if [ ! -f $HOME/BirdNET-Pi/model/labels.txt ];then
+if [ ! -f $labels_txt_path ];then
   [ $DATABASE_LANG == 'not-selected' ] && DATABASE_LANG=en
-  $my_dir/install_language_label.sh -l $DATABASE_LANG \
+  $SCRIPTS_DIR/install_language_label.sh -l $DATABASE_LANG \
   && logger "[$0] Installed new language label file for '$DATABASE_LANG'";
 fi
 
-if ! grep FLICKR_FILTER_EMAIL /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "FLICKR_FILTER_EMAIL=" >> /etc/birdnet/birdnet.conf
+if ! grep FLICKR_FILTER_EMAIL "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "FLICKR_FILTER_EMAIL=" >> "$etc_birdnet_conf_path"
 fi
 
-pytest_installation_status=$(~/BirdNET-Pi/birdnet/bin/python3 -c 'import pkgutil; print("installed" if pkgutil.find_loader("pytest") else "not installed")')
+pytest_installation_status=$($python3_exec_path -c 'import pkgutil; print("installed" if pkgutil.find_loader("pytest") else "not installed")')
 if [[ "$pytest_installation_status" = "not installed" ]];then
-  $HOME/BirdNET-Pi/birdnet/bin/pip3 install -U pip
-  $HOME/BirdNET-Pi/birdnet/bin/pip3 install pytest==7.1.2 pytest-mock==3.7.0
+  $PYTHON3_VE_DIR/pip3 install -U pip
+  $PYTHON3_VE_DIR/pip3 install pytest==7.1.2 pytest-mock==3.7.0
 fi
 
-[ -L ~/BirdSongs/Extracted/weekly_report.php ] || ln -sf ~/BirdNET-Pi/scripts/weekly_report.php ~/BirdSongs/Extracted
+[ -L $EXTRACTED_DIR/weekly_report.php ] || ln -sf $SCRIPTS_DIR/weekly_report.php $EXTRACTED_DIR
 
 if ! grep weekly_report /etc/crontab &>/dev/null;then
-  sed "s/\$USER/$USER/g" $HOME/BirdNET-Pi/templates/weekly_report.cron | sudo tee -a /etc/crontab
+  sed "s/\$USER/$USER/g" $TEMPLATES_DIR/weekly_report.cron | sudo tee -a /etc/crontab
 fi
-if ! grep APPRISE_WEEKLY_REPORT /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "APPRISE_WEEKLY_REPORT=1" >> /etc/birdnet/birdnet.conf
-fi
-
-if ! grep SILENCE_UPDATE_INDICATOR /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "SILENCE_UPDATE_INDICATOR=0" >> /etc/birdnet/birdnet.conf
+if ! grep APPRISE_WEEKLY_REPORT "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "APPRISE_WEEKLY_REPORT=1" >> "$etc_birdnet_conf_path"
 fi
 
-if ! grep '\-\-browser.gatherUsageStats false' $HOME/BirdNET-Pi/templates/birdnet_stats.service &>/dev/null ;then
-  sudo -E sed -i "s|ExecStart=.*|ExecStart=$HOME/BirdNET-Pi/birdnet/bin/streamlit run $HOME/BirdNET-Pi/scripts/plotly_streamlit.py --browser.gatherUsageStats false --server.address localhost --server.baseUrlPath \"/stats\"|" $HOME/BirdNET-Pi/templates/birdnet_stats.service
+if ! grep SILENCE_UPDATE_INDICATOR "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "SILENCE_UPDATE_INDICATOR=0" >> "$etc_birdnet_conf_path"
+fi
+
+if ! grep '\-\-browser.gatherUsageStats false' $TEMPLATES_DIR/birdnet_stats.service &>/dev/null ;then
+  sudo -E sed -i "s|ExecStart=.*|ExecStart=$PYTHON3_VE_DIR/streamlit run $SCRIPTS_DIR/plotly_streamlit.py --browser.gatherUsageStats false --server.address localhost --server.baseUrlPath \"/stats\"|" $TEMPLATES_DIR/birdnet_stats.service
   sudo systemctl daemon-reload && restart_services.sh
 fi
 
 # Make IceCast2 a little more secure
 sudo sed -i.bak -e 's|<!-- <bind-address>.*|<bind-address>127.0.0.1</bind-address>|;s|<!-- <shoutcast-mount>.*|<shoutcast-mount>/stream</shoutcast-mount>|' /etc/icecast2/icecast.xml && if [ -s /etc/icecast2/icecast.xml.bak ] && ! sudo diff /etc/icecast2/icecast.xml /etc/icecast2/icecast.xml.bak > /dev/null; then sudo systemctl restart icecast2; fi
 
-if ! grep FREQSHIFT_TOOL /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "FREQSHIFT_TOOL=sox" >> /etc/birdnet/birdnet.conf
+if ! grep FREQSHIFT_TOOL "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "FREQSHIFT_TOOL=sox" >> "$etc_birdnet_conf_path"
 fi
-if ! grep FREQSHIFT_HI /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "FREQSHIFT_HI=6000" >> /etc/birdnet/birdnet.conf
+if ! grep FREQSHIFT_HI "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "FREQSHIFT_HI=6000" >> "$etc_birdnet_conf_path"
 fi
-if ! grep FREQSHIFT_LO /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "FREQSHIFT_LO=3000" >> /etc/birdnet/birdnet.conf
+if ! grep FREQSHIFT_LO "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "FREQSHIFT_LO=3000" >> "$etc_birdnet_conf_path"
 fi
-if ! grep FREQSHIFT_PITCH /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "FREQSHIFT_PITCH=-1500" >> /etc/birdnet/birdnet.conf
+if ! grep FREQSHIFT_PITCH "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "FREQSHIFT_PITCH=-1500" >> "$etc_birdnet_conf_path"
 fi
-if ! grep ACTIVATE_FREQSHIFT_IN_LIVESTREAM /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "ACTIVATE_FREQSHIFT_IN_LIVESTREAM=\"false\"" >> /etc/birdnet/birdnet.conf
+if ! grep ACTIVATE_FREQSHIFT_IN_LIVESTREAM "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "ACTIVATE_FREQSHIFT_IN_LIVESTREAM=\"false\"" >> "$etc_birdnet_conf_path"
 fi
-if ! grep HEARTBEAT_URL /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "HEARTBEAT_URL=" >> /etc/birdnet/birdnet.conf
+if ! grep HEARTBEAT_URL "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "HEARTBEAT_URL=" >> "$etc_birdnet_conf_path"
 fi
 
-if ! grep MODEL /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "MODEL=BirdNET_6K_GLOBAL_MODEL" >> /etc/birdnet/birdnet.conf
+if ! grep MODEL "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "MODEL=BirdNET_6K_GLOBAL_MODEL" >> "$etc_birdnet_conf_path"
 fi
-if ! grep SF_THRESH /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "SF_THRESH=0.03" >> /etc/birdnet/birdnet.conf
+if ! grep SF_THRESH "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "SF_THRESH=0.03" >> "$etc_birdnet_conf_path"
 fi
-sudo chmod +x ~/BirdNET-Pi/scripts/install_language_label_nm.sh
+sudo chmod +x $SCRIPTS_DIR/install_language_label_nm.sh
 
-sqlite3 $HOME/BirdNET-Pi/scripts/birds.db << EOF
+sqlite3 "$birds_db_path" << EOF
 CREATE INDEX IF NOT EXISTS "detections_Com_Name" ON "detections" ("Com_Name");
 CREATE INDEX IF NOT EXISTS "detections_Date_Time" ON "detections" ("Date" DESC, "Time" DESC);
 EOF
 
-apprise_version=$($HOME/BirdNET-Pi/birdnet/bin/python3 -c "import apprise; print(apprise.__version__)")
-streamlit_version=$($HOME/BirdNET-Pi/birdnet/bin/pip3 show streamlit 2>/dev/null | grep Version | awk '{print $2}')
+apprise_version=$($python3_exec_path -c "import apprise; print(apprise.__version__)")
+streamlit_version=$($PYTHON3_VE_DIR/pip3 show streamlit 2>/dev/null | grep Version | awk '{print $2}')
 
-[[ $apprise_version != "1.2.1" ]] && $HOME/BirdNET-Pi/birdnet/bin/pip3 install apprise==1.2.1
-[[ $streamlit_version != "1.19.0" ]] && $HOME/BirdNET-Pi/birdnet/bin/pip3 install streamlit==1.19.0
+[[ $apprise_version != "1.2.1" ]] && $PYTHON3_VE_DIR/pip3 install apprise==1.2.1
+[[ $streamlit_version != "1.19.0" ]] && $PYTHON3_VE_DIR/pip3 install streamlit==1.19.0
 
-if ! grep -q 'RuntimeMaxSec=' "$HOME/BirdNET-Pi/templates/birdnet_analysis.service"&>/dev/null; then
-    sudo -E sed -i '/\[Service\]/a RuntimeMaxSec=3600' "$HOME/BirdNET-Pi/templates/birdnet_analysis.service"
+if ! grep -q 'RuntimeMaxSec=' "$TEMPLATES_DIR/birdnet_analysis.service"&>/dev/null; then
+    sudo -E sed -i '/\[Service\]/a RuntimeMaxSec=3600' "$TEMPLATES_DIR/birdnet_analysis.service"
     sudo systemctl daemon-reload && restart_services.sh
 fi
 
-if ! grep RAW_SPECTROGRAM /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "RAW_SPECTROGRAM=0" >> /etc/birdnet/birdnet.conf
+if ! grep RAW_SPECTROGRAM "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "RAW_SPECTROGRAM=0" >> "$etc_birdnet_conf_path"
 fi
 
-if ! grep CUSTOM_IMAGE /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "CUSTOM_IMAGE=" >> /etc/birdnet/birdnet.conf
+if ! grep CUSTOM_IMAGE "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "CUSTOM_IMAGE=" >> "$etc_birdnet_conf_path"
 fi
-if ! grep CUSTOM_IMAGE_TITLE /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "CUSTOM_IMAGE_TITLE=\"\"" >> /etc/birdnet/birdnet.conf
-fi
-
-if ! grep APPRISE_ONLY_NOTIFY_SPECIES_NAMES /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "APPRISE_ONLY_NOTIFY_SPECIES_NAMES=\"\"" >> /etc/birdnet/birdnet.conf
-fi
-if ! grep APPRISE_ONLY_NOTIFY_SPECIES_NAMES_2 /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "APPRISE_ONLY_NOTIFY_SPECIES_NAMES_2=\"\"" >> /etc/birdnet/birdnet.conf
+if ! grep CUSTOM_IMAGE_TITLE "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "CUSTOM_IMAGE_TITLE=\"\"" >> "$etc_birdnet_conf_path"
 fi
 
-if ! grep RTSP_STREAM_TO_LIVESTREAM /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "RTSP_STREAM_TO_LIVESTREAM=\"0\"" >> /etc/birdnet/birdnet.conf
+if ! grep APPRISE_ONLY_NOTIFY_SPECIES_NAMES "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "APPRISE_ONLY_NOTIFY_SPECIES_NAMES=\"\"" >> "$etc_birdnet_conf_path"
+fi
+if ! grep APPRISE_ONLY_NOTIFY_SPECIES_NAMES_2 "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "APPRISE_ONLY_NOTIFY_SPECIES_NAMES_2=\"\"" >> "$etc_birdnet_conf_path"
 fi
 
-suntime_installation_status=$(~/BirdNET-Pi/birdnet/bin/python3 -c 'import pkgutil; print("installed" if pkgutil.find_loader("suntime") else "not installed")')
+if ! grep RTSP_STREAM_TO_LIVESTREAM "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "RTSP_STREAM_TO_LIVESTREAM=\"0\"" >> "$etc_birdnet_conf_path"
+fi
+
+suntime_installation_status=$($python3_exec_path -c 'import pkgutil; print("installed" if pkgutil.find_loader("suntime") else "not installed")')
 if [[ "$suntime_installation_status" = "not installed" ]];then
-  $HOME/BirdNET-Pi/birdnet/bin/pip3 install -U pip
-  $HOME/BirdNET-Pi/birdnet/bin/pip3 install suntime
+  $PYTHON3_VE_DIR/pip3 install -U pip
+  $PYTHON3_VE_DIR/pip3 install suntime
 fi
 
 # For new Advanced Setting Logging level options
-if ! grep LogLevel_BirdnetRecordingService /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "LogLevel_BirdnetRecordingService=\"error\"" >> /etc/birdnet/birdnet.conf
+if ! grep LogLevel_BirdnetRecordingService "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "LogLevel_BirdnetRecordingService=\"error\"" >> "$etc_birdnet_conf_path"
 fi
 
-if ! grep LogLevel_LiveAudioStreamService /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "LogLevel_LiveAudioStreamService=\"error\"" >> /etc/birdnet/birdnet.conf
+if ! grep LogLevel_LiveAudioStreamService "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "LogLevel_LiveAudioStreamService=\"error\"" >> "$etc_birdnet_conf_path"
 fi
 
-if ! grep LogLevel_SpectrogramViewerService /etc/birdnet/birdnet.conf &>/dev/null;then
-  sudo -u$USER echo "LogLevel_SpectrogramViewerService=\"error\"" >> /etc/birdnet/birdnet.conf
+if ! grep LogLevel_SpectrogramViewerService "$etc_birdnet_conf_path" &>/dev/null;then
+  sudo -u$USER echo "LogLevel_SpectrogramViewerService=\"error\"" >> "$etc_birdnet_conf_path"
 fi
 
-if grep -q '^MODEL=BirdNET_GLOBAL_3K_V2.2_Model_FP16$' /etc/birdnet/birdnet.conf;then
-  language=$(grep "^DATABASE_LANG=" /etc/birdnet/birdnet.conf | cut -d= -f2)
-  sed -i 's/BirdNET_GLOBAL_3K_V2.2_Model_FP16/BirdNET_GLOBAL_3K_V2.3_Model_FP16/' /etc/birdnet/birdnet.conf
-  sed -i 's/BirdNET_GLOBAL_3K_V2.2_Model_FP16/BirdNET_GLOBAL_3K_V2.3_Model_FP16/' $HOME/BirdNET-Pi/scripts/thisrun.txt
-  sed -i 's/BirdNET_GLOBAL_3K_V2.2_Model_FP16/BirdNET_GLOBAL_3K_V2.3_Model_FP16/' $HOME/BirdNET-Pi/birdnet.conf
-  cp -f $HOME/BirdNET-Pi/model/labels.txt $HOME/BirdNET-Pi/model/labels.txt.old
-  sudo chmod +x $HOME/BirdNET-Pi/scripts/install_language_label_nm.sh && $HOME/BirdNET-Pi/scripts/install_language_label_nm.sh -l "$language"
+if grep -q '^MODEL=BirdNET_GLOBAL_3K_V2.2_Model_FP16$' "$etc_birdnet_conf_path";then
+  language=$(grep "^DATABASE_LANG=" "$etc_birdnet_conf_path" | cut -d= -f2)
+  sed -i 's/BirdNET_GLOBAL_3K_V2.2_Model_FP16/BirdNET_GLOBAL_3K_V2.3_Model_FP16/' "$etc_birdnet_conf_path"
+  sed -i 's/BirdNET_GLOBAL_3K_V2.2_Model_FP16/BirdNET_GLOBAL_3K_V2.3_Model_FP16/' "$thisrun_txt_path"
+  sed -i 's/BirdNET_GLOBAL_3K_V2.2_Model_FP16/BirdNET_GLOBAL_3K_V2.3_Model_FP16/' "$birdnet_conf_path"
+  cp -f "$labels_txt_path" "$labels_txt_old_path"
+  sudo chmod +x "$SCRIPTS_DIR"/install_language_label_nm.sh && "$SCRIPTS_DIR"/install_language_label_nm.sh -l "$language"
 fi
 
 # Symlink the new config directory into the Extracted & Local Bin directory

--- a/scripts/update_birdnet_snippets.sh
+++ b/scripts/update_birdnet_snippets.sh
@@ -248,6 +248,9 @@ if grep -q '^MODEL=BirdNET_GLOBAL_3K_V2.2_Model_FP16$' "$etc_birdnet_conf_path";
   sudo chmod +x "$SCRIPTS_DIR"/install_language_label_nm.sh && "$SCRIPTS_DIR"/install_language_label_nm.sh -l "$language"
 fi
 
+# Link in new bash script common.sh to local/bin
+ln -sf ${SCRIPTS_DIR}/common.sh /usr/local/bin/
+
 # Symlink the new config directory into the Extracted & Local Bin directory
 [ -L ~/BirdSongs/Extracted/config ] || ln -sf ~/BirdNET-Pi/config ~/BirdSongs/Extracted
 [ -L /usr/local/bin/config ] || ln -sf ~/BirdNET-Pi/config /usr/local/bin/

--- a/scripts/update_caddyfile.sh
+++ b/scripts/update_caddyfile.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/common.sh
+
+SCRIPTS_DIR="$(getDirectory 'scripts')"
+EXTRACTED_DIR="$(getDirectory 'extracted')"
+
 source /etc/birdnet/birdnet.conf
-my_dir=$HOME/BirdNET-Pi/scripts
 set -x
 [ -d /etc/caddy ] || mkdir /etc/caddy
 if [ -f /etc/caddy/Caddyfile ];then
@@ -10,7 +15,7 @@ if ! [ -z ${CADDY_PWD} ];then
 HASHWORD=$(caddy hash-password --plaintext ${CADDY_PWD})
 cat << EOF > /etc/caddy/Caddyfile
 http:// ${BIRDNETPI_URL} {
-  root * ${EXTRACTED}
+  root * ${EXTRACTED_DIR}
   file_server browse
   handle /By_Date/* {
     file_server browse
@@ -46,7 +51,7 @@ EOF
 else
   cat << EOF > /etc/caddy/Caddyfile
 http:// ${BIRDNETPI_URL} {
-  root * ${EXTRACTED}
+  root * ${EXTRACTED_DIR}
   file_server browse
   handle /By_Date/* {
     file_server browse

--- a/scripts/update_species.sh
+++ b/scripts/update_species.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/common.sh
+
+birds_db_path="$(getFilePath 'birds.db')"
+# Replace the home path (which is the user executing) with the home path for Birdnet
+id_file_path="$(getFilePath 'IdentifiedSoFar.txt')"
+
 # Update the species list
 #set -x
 source /etc/birdnet/birdnet.conf
-if [ -f $HOME/BirdNET-Pi/scripts/birds.db ];then
-sqlite3 $HOME/BirdNET-Pi/scripts/birds.db "SELECT DISTINCT(Com_Name) FROM detections" | sort >  ${IDFILE}
+if [ -f "$birds_db_path" ];then
+sqlite3 "$birds_db_path" "SELECT DISTINCT(Com_Name) FROM detections" | sort >  ${id_file_path}
 fi

--- a/scripts/weekly_report.sh
+++ b/scripts/weekly_report.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/common.sh
+
+apprise_txt_path="$(getFilePath 'apprise.txt')"
+PYTHON3_VE_DIR="$(getDirectory 'python3_ve')"
+
 source /etc/birdnet/birdnet.conf
 if [ ${APPRISE_WEEKLY_REPORT} == 1 ];then
 	NOTIFICATION=$(curl 'localhost/views.php?view=Weekly%20Report&ascii=true')
 	NOTIFICATION=${NOTIFICATION#*#}
 	firstLine=`echo "${NOTIFICATION}" | head -1`
 	NOTIFICATION=`echo "${NOTIFICATION}" | tail -n +2`
-	$HOME/BirdNET-Pi/birdnet/bin/apprise -vv -t "${firstLine}" -b "${NOTIFICATION}" --input-format=html --config=$HOME/BirdNET-Pi/apprise.txt
+	"$PYTHON3_VE_DIR"/apprise -vv -t "${firstLine}" -b "${NOTIFICATION}" --input-format=html --config="$apprise_txt_path"
 fi

--- a/scripts/write_config.sh
+++ b/scripts/write_config.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/bash
+BINDIR=$(cd $(dirname $0) && pwd)
+. ${BINDIR}/common.sh
+
 # Writes variables to config file
-birdnetpi_dir=$HOME/BirdNET-Pi
+birdnetpi_dir="$(getDirectory 'birdnet_pi')"
 birders_conf=${birdnetpi_dir}/Birders_Guide_Installer_Configuration.txt
 sed -i s/'^LATITUDE=$'/"LATITUDE=${new_lat}"/g ${birders_conf}
 sed -i s/'^LONGITUDE=$'/"LONGITUDE=${new_lon}"/g ${birders_conf}

--- a/tests/test_filepath_resolver_common.sh
+++ b/tests/test_filepath_resolver_common.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+#set -e
+
+#BINDIR=$(cd $(dirname $0) && pwd)
+. ../scripts/common.sh
+
+#We only need these setting values during testing
+RECS_DIR=$HOME/BirdSongs
+PROCESSED=${RECS_DIR}/Processed
+EXTRACTED=${RECS_DIR}/Extracted
+IDFILE=$HOME/BirdNET-Pi/IdentifiedSoFar.txt
+
+#Initialize to expected home location
+HOME="/home/pi"
+
+#Test over varring home folders
+TEST_HOMES=('/home/pi' '/home/another_user' '/opt/birdnet')
+
+for _test_home in "${TEST_HOMES[@]}"; do
+  HOME="$_test_home"
+
+  ## DIRECTORY TESTS
+  result="$(getDirectory 'birdnet_pi')"
+  expected="$_test_home/BirdNET-Pi"
+  [ "$result" == $expected ] || echo "directory 'birdnet_pi' failed, expected: $expected - got: $result"
+
+  result="$(getDirectory 'recs_dir')"
+  expected="$_test_home/BirdSongs"
+  [ "$result" == $expected ] || echo "directory 'recs_dir' failed, expected: $expected - got: $result"
+
+  result="$(getDirectory 'processed')"
+  expected="$_test_home/BirdSongs/Processed"
+  [ "$result" == $expected ] || echo "directory 'processed' failed, expected: $expected - got: $result"
+
+  result="$(getDirectory 'extracted')"
+  expected="$_test_home/BirdSongs/Extracted"
+  [ "$result" == $expected ] || echo "directory 'extracted' failed, expected: $expected - got: $result"
+
+  result="$(getDirectory 'extracted_by_date')"
+  expected="$_test_home/BirdSongs/Extracted/By_Date"
+  [ "$result" == $expected ] || echo "directory 'extracted_by_date' failed, expected: $expected - got: $result"
+
+  result="$(getDirectory 'shifted_audio')"
+  expected="$_test_home/BirdSongs/Extracted/By_Date/shifted"
+  [ "$result" == $expected ] || echo "directory 'shifted_audio' failed, expected: $expected - got: $result"
+
+  result="$(getDirectory 'database')"
+  expected="$_test_home/BirdNET-Pi/database"
+  [ "$result" == $expected ] || echo "directory 'database' failed, expected: $expected - got: $result"
+
+  result="$(getDirectory 'config')"
+  expected="$_test_home/BirdNET-Pi/config"
+  [ "$result" == $expected ] || echo "directory 'config' failed, expected: $expected - got: $result"
+
+  result="$(getDirectory 'models')"
+  expected="$_test_home/BirdNET-Pi/model"
+  [ "$result" == $expected ] || echo "directory 'models' failed, expected: $expected - got: $result"
+
+  result="$(getDirectory 'python3_ve')"
+  expected="$_test_home/BirdNET-Pi/birdnet/bin"
+  [ "$result" == $expected ] || echo "directory 'python3_ve' failed, expected: $expected - got: $result"
+
+  result="$(getDirectory 'scripts')"
+  expected="$_test_home/BirdNET-Pi/scripts"
+  [ "$result" == $expected ] || echo "directory 'scripts' failed, expected: $expected - got: $result"
+
+  result="$(getDirectory 'stream_data')"
+  expected="$_test_home/BirdSongs/StreamData"
+  [ "$result" == $expected ] || echo "directory 'stream_data' failed, expected: $expected - got: $result"
+
+  result="$(getDirectory 'templates')"
+  expected="$_test_home/BirdNET-Pi/templates"
+  [ "$result" == $expected ] || echo "directory 'templates' failed, expected: $expected - got: $result"
+
+  result="$(getDirectory 'web')"
+  expected="$_test_home/BirdNET-Pi/homepage"
+  [ "$result" == $expected ] || echo "directory 'web' failed, expected: $expected - got: $result"
+
+  ## FILE PATH TESTS
+  result="$(getFilePath 'analyzing_now.txt')"
+  expected="$_test_home/BirdNET-Pi/analyzing_now.txt"
+  [ "$result" == $expected ] || echo "file path 'analyzing_now.txt' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'apprise.txt')"
+  expected="$_test_home/BirdNET-Pi/apprise.txt"
+  [ "$result" == $expected ] || echo "file path 'apprise.txt' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'birdnet.conf')"
+  expected="$_test_home/BirdNET-Pi/birdnet.conf"
+  [ "$result" == $expected ] || echo "file path 'birdnet.conf' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'etc_birdnet.conf')"
+  expected="/etc/birdnet/birdnet.conf"
+  [ "$result" == $expected ] || echo "file path 'etc_birdnet.conf' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'BirdDB.txt')"
+  expected="$_test_home/BirdNET-Pi/BirdDB.txt"
+  [ "$result" == $expected ] || echo "file path 'BirdDB.txt' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'birds.db')"
+  expected="$_test_home/BirdNET-Pi/scripts/birds.db"
+  [ "$result" == $expected ] || echo "file path 'birds.db' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'blacklisted_images.txt')"
+  expected="$_test_home/BirdNET-Pi/scripts/blacklisted_images.txt"
+  [ "$result" == $expected ] || echo "file path 'blacklisted_images.txt'' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'disk_check_exclude.txt')"
+  expected="$_test_home/BirdNET-Pi/scripts/disk_check_exclude.txt"
+  [ "$result" == $expected ] || echo "file path 'disk_check_exclude.txt' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'email_template')"
+  expected="$_test_home/BirdNET-Pi/scripts/email_template"
+  [ "$result" == $expected ] || echo "file path 'email_template' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'email_template2')"
+  expected="$_test_home/BirdNET-Pi/scripts/email_template2"
+  [ "$result" == $expected ] || echo "file path 'email_template2' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'exclude_species_list.txt')"
+  expected="$_test_home/BirdNET-Pi/scripts/exclude_species_list.txt"
+  [ "$result" == $expected ] || echo "file path 'exclude_species_list.txt' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'firstrun.ini')"
+  expected="$_test_home/BirdNET-Pi/firstrun.ini"
+  [ "$result" == $expected ] || echo "file path 'firstrun.ini' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath '.gotty')"
+  expected="$_test_home/.gotty"
+  [ "$result" == $expected ] || echo "file path '.gotty' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'HUMAN.txt')"
+  expected="$_test_home/BirdNET-Pi/HUMAN.txt"
+  [ "$result" == $expected ] || echo "file path 'HUMAN.txt' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'IdentifiedSoFar.txt')"
+  expected="$_test_home/BirdNET-Pi/IdentifiedSoFar.txt"
+  [ "$result" == $expected ] || echo "file path 'IdentifiedSoFar.txt' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'include_species_list.txt')"
+  expected="$_test_home/BirdNET-Pi/scripts/include_species_list.txt"
+  [ "$result" == $expected ] || echo "file path 'include_species_list.txt' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'labels.txt')"
+  expected="$_test_home/BirdNET-Pi/model/labels.txt"
+  [ "$result" == $expected ] || echo "file path 'labels.txt' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'labels.txt.old')"
+  expected="$_test_home/BirdNET-Pi/model/labels.txt.old"
+  [ "$result" == $expected ] || echo "file path 'labels.txt.old' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'labels_flickr.txt')"
+  expected="$_test_home/BirdNET-Pi/model/labels_flickr.txt"
+  [ "$result" == $expected ] || echo "file path 'labels_flickr.txt' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'labels_l18n.zip')"
+  expected="$_test_home/BirdNET-Pi/model/labels_l18n.zip"
+  [ "$result" == $expected ] || echo "file path 'labels_l18n.zip' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'labels_lang.txt')"
+  expected="$_test_home/BirdNET-Pi/model/labels_lang.txt"
+  [ "$result" == $expected ] || echo "file path 'labels_lang.txt' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'labels_nm.zip')"
+  expected="$_test_home/BirdNET-Pi/model/labels_nm.zip"
+  [ "$result" == $expected ] || echo "file path 'labels_nm.zip' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'lastrun.txt')"
+  expected="$_test_home/BirdNET-Pi/scripts/lastrun.txt"
+  [ "$result" == $expected ] || echo "file path 'lastrun.txt' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'python3')"
+  expected="$_test_home/BirdNET-Pi/birdnet/bin/python3 "
+  [ "$result" == "$expected" ] || echo "file path 'python3' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'python3_appraise')"
+  expected="$_test_home/BirdNET-Pi/birdnet/bin/apprise "
+  [ "$result" == "$expected" ] || echo "file path 'python3_appraise' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'species.py')"
+  expected="$_test_home/BirdNET-Pi/scripts/species.py"
+  [ "$result" == $expected ] || echo "file path 'species.py' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'thisrun.txt')"
+  expected="$_test_home/BirdNET-Pi/scripts/thisrun.txt"
+  [ "$result" == $expected ] || echo "file path 'thisrun.txt' failed, expected: $expected - got: $result"
+
+done

--- a/tests/test_filepath_resolver_common.sh
+++ b/tests/test_filepath_resolver_common.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 #set -e
 
-#BINDIR=$(cd $(dirname $0) && pwd)
-. ../scripts/common.sh
+BINDIR=$(cd $(dirname $0) && pwd)
+if [ -f "${BINDIR}/scripts/common.sh" ]; then
+. "${BINDIR}/scripts/common.sh"
+elif [ -f "${PWD%/*}/scripts/common.sh" ]; then
+. "${PWD%/*}/scripts/common.sh"
+else
+. "${PWD%}/scripts/common.sh"
+fi
 
 #We only need these setting values during testing
 RECS_DIR=$HOME/BirdSongs
@@ -13,161 +19,173 @@ IDFILE=$HOME/BirdNET-Pi/IdentifiedSoFar.txt
 #Initialize to expected home location
 HOME="/home/pi"
 
-#Test over varring home folders
+#Test over varying home folders
 TEST_HOMES=('/home/pi' '/home/another_user' '/opt/birdnet')
 
 for _test_home in "${TEST_HOMES[@]}"; do
   HOME="$_test_home"
 
-  ## DIRECTORY TESTS
+  ############################
+  ## Directory Path Tests
+  ############################
+  result="$(getDirectory 'home')"
+  expected="$_test_home"
+  [ "$result" == "$expected" ] || echo "directory 'home' failed, expected: $expected - got: $result"
+
   result="$(getDirectory 'birdnet_pi')"
   expected="$_test_home/BirdNET-Pi"
-  [ "$result" == $expected ] || echo "directory 'birdnet_pi' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "directory 'birdnet_pi' failed, expected: $expected - got: $result"
 
   result="$(getDirectory 'recs_dir')"
   expected="$_test_home/BirdSongs"
-  [ "$result" == $expected ] || echo "directory 'recs_dir' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "directory 'recs_dir' failed, expected: $expected - got: $result"
 
   result="$(getDirectory 'processed')"
   expected="$_test_home/BirdSongs/Processed"
-  [ "$result" == $expected ] || echo "directory 'processed' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "directory 'processed' failed, expected: $expected - got: $result"
 
   result="$(getDirectory 'extracted')"
   expected="$_test_home/BirdSongs/Extracted"
-  [ "$result" == $expected ] || echo "directory 'extracted' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "directory 'extracted' failed, expected: $expected - got: $result"
 
   result="$(getDirectory 'extracted_by_date')"
   expected="$_test_home/BirdSongs/Extracted/By_Date"
-  [ "$result" == $expected ] || echo "directory 'extracted_by_date' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "directory 'extracted_by_date' failed, expected: $expected - got: $result"
 
   result="$(getDirectory 'shifted_audio')"
   expected="$_test_home/BirdSongs/Extracted/By_Date/shifted"
-  [ "$result" == $expected ] || echo "directory 'shifted_audio' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "directory 'shifted_audio' failed, expected: $expected - got: $result"
 
   result="$(getDirectory 'database')"
   expected="$_test_home/BirdNET-Pi/database"
-  [ "$result" == $expected ] || echo "directory 'database' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "directory 'database' failed, expected: $expected - got: $result"
 
   result="$(getDirectory 'config')"
   expected="$_test_home/BirdNET-Pi/config"
-  [ "$result" == $expected ] || echo "directory 'config' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "directory 'config' failed, expected: $expected - got: $result"
 
   result="$(getDirectory 'models')"
   expected="$_test_home/BirdNET-Pi/model"
-  [ "$result" == $expected ] || echo "directory 'models' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "directory 'models' failed, expected: $expected - got: $result"
 
   result="$(getDirectory 'python3_ve')"
   expected="$_test_home/BirdNET-Pi/birdnet/bin"
-  [ "$result" == $expected ] || echo "directory 'python3_ve' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "directory 'python3_ve' failed, expected: $expected - got: $result"
 
   result="$(getDirectory 'scripts')"
   expected="$_test_home/BirdNET-Pi/scripts"
-  [ "$result" == $expected ] || echo "directory 'scripts' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "directory 'scripts' failed, expected: $expected - got: $result"
 
   result="$(getDirectory 'stream_data')"
   expected="$_test_home/BirdSongs/StreamData"
-  [ "$result" == $expected ] || echo "directory 'stream_data' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "directory 'stream_data' failed, expected: $expected - got: $result"
 
   result="$(getDirectory 'templates')"
   expected="$_test_home/BirdNET-Pi/templates"
-  [ "$result" == $expected ] || echo "directory 'templates' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "directory 'templates' failed, expected: $expected - got: $result"
 
   result="$(getDirectory 'web')"
   expected="$_test_home/BirdNET-Pi/homepage"
-  [ "$result" == $expected ] || echo "directory 'web' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "directory 'web' failed, expected: $expected - got: $result"
 
-  ## FILE PATH TESTS
+  ############################
+  # FILE PATH TESTS
+  ############################
   result="$(getFilePath 'analyzing_now.txt')"
   expected="$_test_home/BirdNET-Pi/analyzing_now.txt"
-  [ "$result" == $expected ] || echo "file path 'analyzing_now.txt' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'analyzing_now.txt' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'apprise.txt')"
   expected="$_test_home/BirdNET-Pi/apprise.txt"
-  [ "$result" == $expected ] || echo "file path 'apprise.txt' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'apprise.txt' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'birdnet.conf')"
   expected="$_test_home/BirdNET-Pi/birdnet.conf"
-  [ "$result" == $expected ] || echo "file path 'birdnet.conf' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'birdnet.conf' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'etc_birdnet.conf')"
   expected="/etc/birdnet/birdnet.conf"
-  [ "$result" == $expected ] || echo "file path 'etc_birdnet.conf' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'etc_birdnet.conf' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'BirdDB.txt')"
   expected="$_test_home/BirdNET-Pi/BirdDB.txt"
-  [ "$result" == $expected ] || echo "file path 'BirdDB.txt' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'BirdDB.txt' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'birds.db')"
   expected="$_test_home/BirdNET-Pi/scripts/birds.db"
-  [ "$result" == $expected ] || echo "file path 'birds.db' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'birds.db' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'blacklisted_images.txt')"
   expected="$_test_home/BirdNET-Pi/scripts/blacklisted_images.txt"
-  [ "$result" == $expected ] || echo "file path 'blacklisted_images.txt'' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'blacklisted_images.txt'' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'disk_check_exclude.txt')"
   expected="$_test_home/BirdNET-Pi/scripts/disk_check_exclude.txt"
-  [ "$result" == $expected ] || echo "file path 'disk_check_exclude.txt' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'disk_check_exclude.txt' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'email_template')"
   expected="$_test_home/BirdNET-Pi/scripts/email_template"
-  [ "$result" == $expected ] || echo "file path 'email_template' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'email_template' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'email_template2')"
   expected="$_test_home/BirdNET-Pi/scripts/email_template2"
-  [ "$result" == $expected ] || echo "file path 'email_template2' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'email_template2' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'exclude_species_list.txt')"
   expected="$_test_home/BirdNET-Pi/scripts/exclude_species_list.txt"
-  [ "$result" == $expected ] || echo "file path 'exclude_species_list.txt' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'exclude_species_list.txt' failed, expected: $expected - got: $result"
+
+  result="$(getFilePath 'filepath_map.json')"
+  expected="$_test_home/BirdNET-Pi/config/filepath_map.json"
+  [ "$result" == "$expected" ] || echo "file path 'filepath_map.json' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'firstrun.ini')"
   expected="$_test_home/BirdNET-Pi/firstrun.ini"
-  [ "$result" == $expected ] || echo "file path 'firstrun.ini' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'firstrun.ini' failed, expected: $expected - got: $result"
 
   result="$(getFilePath '.gotty')"
   expected="$_test_home/.gotty"
-  [ "$result" == $expected ] || echo "file path '.gotty' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path '.gotty' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'HUMAN.txt')"
   expected="$_test_home/BirdNET-Pi/HUMAN.txt"
-  [ "$result" == $expected ] || echo "file path 'HUMAN.txt' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'HUMAN.txt' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'IdentifiedSoFar.txt')"
   expected="$_test_home/BirdNET-Pi/IdentifiedSoFar.txt"
-  [ "$result" == $expected ] || echo "file path 'IdentifiedSoFar.txt' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'IdentifiedSoFar.txt' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'include_species_list.txt')"
   expected="$_test_home/BirdNET-Pi/scripts/include_species_list.txt"
-  [ "$result" == $expected ] || echo "file path 'include_species_list.txt' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'include_species_list.txt' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'labels.txt')"
   expected="$_test_home/BirdNET-Pi/model/labels.txt"
-  [ "$result" == $expected ] || echo "file path 'labels.txt' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'labels.txt' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'labels.txt.old')"
   expected="$_test_home/BirdNET-Pi/model/labels.txt.old"
-  [ "$result" == $expected ] || echo "file path 'labels.txt.old' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'labels.txt.old' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'labels_flickr.txt')"
   expected="$_test_home/BirdNET-Pi/model/labels_flickr.txt"
-  [ "$result" == $expected ] || echo "file path 'labels_flickr.txt' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'labels_flickr.txt' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'labels_l18n.zip')"
   expected="$_test_home/BirdNET-Pi/model/labels_l18n.zip"
-  [ "$result" == $expected ] || echo "file path 'labels_l18n.zip' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'labels_l18n.zip' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'labels_lang.txt')"
   expected="$_test_home/BirdNET-Pi/model/labels_lang.txt"
-  [ "$result" == $expected ] || echo "file path 'labels_lang.txt' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'labels_lang.txt' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'labels_nm.zip')"
   expected="$_test_home/BirdNET-Pi/model/labels_nm.zip"
-  [ "$result" == $expected ] || echo "file path 'labels_nm.zip' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'labels_nm.zip' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'lastrun.txt')"
   expected="$_test_home/BirdNET-Pi/scripts/lastrun.txt"
-  [ "$result" == $expected ] || echo "file path 'lastrun.txt' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'lastrun.txt' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'python3')"
   expected="$_test_home/BirdNET-Pi/birdnet/bin/python3 "
@@ -179,10 +197,10 @@ for _test_home in "${TEST_HOMES[@]}"; do
 
   result="$(getFilePath 'species.py')"
   expected="$_test_home/BirdNET-Pi/scripts/species.py"
-  [ "$result" == $expected ] || echo "file path 'species.py' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'species.py' failed, expected: $expected - got: $result"
 
   result="$(getFilePath 'thisrun.txt')"
   expected="$_test_home/BirdNET-Pi/scripts/thisrun.txt"
-  [ "$result" == $expected ] || echo "file path 'thisrun.txt' failed, expected: $expected - got: $result"
+  [ "$result" == "$expected" ] || echo "file path 'thisrun.txt' failed, expected: $expected - got: $result"
 
 done


### PR DESCRIPTION
Thorough review of what I've done and additional testing needed since this can break systems.

Same implementation as with the Python scripts (#930 & #925) - Created a file path and directory resolver that can be called with a file name or directory and returns a path relative to a home path (which is still currently fixed to user id 1000 but the intention is that it can be easily changed)

Updated all scripts that had hard coded paths to use the new resolver EXCEPT the install scripts. There were no logic changes with any of the scripts, just path replacements.

I've tested nearly all scripts the best I can and also tested the destructive scripts such as clean_all_data.sh, uninstall.sh, created_db.sh which all function correctly

I haven't tested the following (e.g don't use Apprise) but on principle they should still work:
```
weekly_report.sh
custom_recording.sh
```
And this script seems unused:
`write_config.sh`

Included test_filepath_resolver_common.sh which runs a simple list of tests against the new get_file_path and get_directory to ensure they return what we expect. This proves useful as sometimes getting the correct output with string manipulation was sometimes be tricky
The script should be run first to validate everything is ok, it should return nothing if all was ok
./tests/test_filepath_resolver_common.sh

Relies upon #925 for /config/filepath_map.json and the installation of jq (a command line parser for JSON files https://stedolan.github.io/jq/)