### PR TITLE
Make pulseaudio installation optional

### DIFF
--- a/birdnet.conf-defaults
+++ b/birdnet.conf-defaults
@@ -219,3 +219,15 @@ CUSTOM_IMAGE_TITLE=""
 LAST_RUN=
 THIS_RUN=
 IDFILE=$HOME/BirdNET-Pi/IdentifiedSoFar.txt
+
+################################################################################
+#------------------------------  Installation ---------------------------------#
+################################################################################
+
+## These are options which define which packages are installed when the system
+## is first set-up. At the moment this is intended to help eliminate packages
+## which pull in a large number of dependencies, and may not be needed when
+## running in e.g. a container, or in some parts of a client/server setup.
+
+## pulseaudio is used for recording from a local sound source
+INSTALL_PULSEAUDIO=true

--- a/scripts/install_config.sh
+++ b/scripts/install_config.sh
@@ -249,6 +249,18 @@ CUSTOM_IMAGE_TITLE=""
 LAST_RUN=
 THIS_RUN=
 IDFILE=$HOME/BirdNET-Pi/IdentifiedSoFar.txt
+
+################################################################################
+#------------------------------  Installation ---------------------------------#
+################################################################################
+
+## These are options which define which packages are installed when the system
+## is first set-up. At the moment this is intended to help eliminate packages
+## which pull in a large number of dependencies, and may not be needed when
+## running in e.g. a container, or in some parts of a client/server setup.
+
+## pulseaudio is used for recording from a local sound source
+INSTALL_PULSEAUDIO=true
 EOF
 }
 

--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -12,15 +12,18 @@ export HOME=$HOME
 export PYTHON_VIRTUAL_ENV="$HOME/BirdNET-Pi/birdnet/bin/python3"
 
 install_depends() {
-  apt install -y debian-keyring debian-archive-keyring apt-transport-https
+  apt-get install -y debian-keyring debian-archive-keyring apt-transport-https
   curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
   curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
-  apt -qqq update && apt -qqy upgrade
+  apt-get -qqq update && apt-get -qqy upgrade
   echo "icecast2 icecast2/icecast-setup boolean false" | debconf-set-selections
-  apt install -qqy caddy ftpd sqlite3 php-sqlite3 alsa-utils \
+  apt-get install -qqy caddy ftpd sqlite3 php-sqlite3 alsa-utils \
     pulseaudio avahi-utils sox libsox-fmt-mp3 php php-fpm php-curl php-xml \
     php-zip icecast2 swig ffmpeg wget unzip curl cmake make bc libjpeg-dev \
     zlib1g-dev python3-dev python3-pip python3-venv lsof net-tools
+  if $INSTALL_PULSEAUDIO; then
+    apt-get install -qqy pulseaudio
+  fi
 }
 
 

--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -18,7 +18,7 @@ install_depends() {
   apt-get -qqq update && apt-get -qqy upgrade
   echo "icecast2 icecast2/icecast-setup boolean false" | debconf-set-selections
   apt-get install -qqy caddy ftpd sqlite3 php-sqlite3 alsa-utils \
-    pulseaudio avahi-utils sox libsox-fmt-mp3 php php-fpm php-curl php-xml \
+    avahi-utils sox libsox-fmt-mp3 php php-fpm php-curl php-xml \
     php-zip icecast2 swig ffmpeg wget unzip curl cmake make bc libjpeg-dev \
     zlib1g-dev python3-dev python3-pip python3-venv lsof net-tools
   if $INSTALL_PULSEAUDIO; then


### PR DESCRIPTION
Make pulseaudio installation optional, as it pulls in a lot of dependencies.

I'm running BirdNET-Pi in a container, and I'm slowly going through to trying to work out how to bring the image size down a bit. The other big culprit is ffmpeg, which I'm currently investigating.

One thing I'm not sure about is whether installation-time only options like this might be better in a separate file?

(This also switches from apt to apt-get, as I believe apt is supposed to be for interactive use only, whereas apt-get's commands, options, etc are supposed to be stable enough for scripted use.)