### PR TITLE
Add simple install-time configuration override mechanism

### DIFF
--- a/scripts/install_config.sh
+++ b/scripts/install_config.sh
@@ -250,6 +250,8 @@ LAST_RUN=
 THIS_RUN=
 IDFILE=$HOME/BirdNET-Pi/IdentifiedSoFar.txt
 EOF
+  local overf=$my_dir/birdnet.conf.override
+  [ -e $overf ] && cat $overf >>$birdnet_conf
 }
 
 # Checks for a birdnet.conf file


### PR DESCRIPTION
Add a mechanism for e.g. container build scripts to override selected entries in the default birdnet.conf file without having to duplicate the whole file (and potentially end up out-of-step when it changes.) Currently envisaged use-case for this is to set and unset INSTALL_xxx variables like the one introduced in #974.