### PR TITLE
Option to use static ffmpeg build to reduce size

### DIFF
--- a/birdnet.conf-defaults
+++ b/birdnet.conf-defaults
@@ -231,3 +231,15 @@ IDFILE=$HOME/BirdNET-Pi/IdentifiedSoFar.txt
 
 ## pulseaudio is used for recording from a local sound source
 INSTALL_PULSEAUDIO=true
+
+## a statically linked ffmpeg build can save us a lot of space by avoiding
+## having to pull-in loads of debian dependencies. Set this to 'native' to use
+## the debian version of ffmpeg, or 'static' to use the static version.
+INSTALL_FFMPEG=native
+
+## details for the static ffmpeg version
+
+FFMPEG_URL_amd64=https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
+FFMPEG_MD5_amd64=bef7015ca2fd7f19057cad0262d970d2
+FFMPEG_URL_arm64=https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-arm64-static.tar.xz
+FFMPEG_MD5_arm64=67ec92e54b3d0f5dbad4e72404c30af7

--- a/birdnet.conf-defaults
+++ b/birdnet.conf-defaults
@@ -219,3 +219,15 @@ CUSTOM_IMAGE_TITLE=""
 LAST_RUN=
 THIS_RUN=
 IDFILE=$HOME/BirdNET-Pi/IdentifiedSoFar.txt
+
+################################################################################
+#------------------------------  Installation ---------------------------------#
+################################################################################
+
+## These are options which define which packages are installed when the system
+## is first set-up. At the moment this is intended to help eliminate packages
+## which pull in a large number of dependencies, and may not be needed when
+## running in e.g. a container, or in some parts of a client/server setup.
+
+## pulseaudio is used for recording from a local sound source
+INSTALL_PULSEAUDIO=true

--- a/scripts/install_config.sh
+++ b/scripts/install_config.sh
@@ -261,6 +261,18 @@ IDFILE=$HOME/BirdNET-Pi/IdentifiedSoFar.txt
 
 ## pulseaudio is used for recording from a local sound source
 INSTALL_PULSEAUDIO=true
+
+## a statically linked ffmpeg build can save us a lot of space by avoiding
+## having to pull-in loads of debian dependencies. Set this to 'native' to use
+## the debian version of ffmpeg, or 'static' to use the static version.
+INSTALL_FFMPEG=native
+
+## details for the static ffmpeg version
+
+FFMPEG_URL_amd64=https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
+FFMPEG_MD5_amd64=bef7015ca2fd7f19057cad0262d970d2
+FFMPEG_URL_arm64=https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-arm64-static.tar.xz
+FFMPEG_MD5_arm64=67ec92e54b3d0f5dbad4e72404c30af7
 EOF
 }
 

--- a/scripts/install_config.sh
+++ b/scripts/install_config.sh
@@ -249,6 +249,18 @@ CUSTOM_IMAGE_TITLE=""
 LAST_RUN=
 THIS_RUN=
 IDFILE=$HOME/BirdNET-Pi/IdentifiedSoFar.txt
+
+################################################################################
+#------------------------------  Installation ---------------------------------#
+################################################################################
+
+## These are options which define which packages are installed when the system
+## is first set-up. At the moment this is intended to help eliminate packages
+## which pull in a large number of dependencies, and may not be needed when
+## running in e.g. a container, or in some parts of a client/server setup.
+
+## pulseaudio is used for recording from a local sound source
+INSTALL_PULSEAUDIO=true
 EOF
 }
 

--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -12,15 +12,18 @@ export HOME=$HOME
 export PYTHON_VIRTUAL_ENV="$HOME/BirdNET-Pi/birdnet/bin/python3"
 
 install_depends() {
-  apt install -y debian-keyring debian-archive-keyring apt-transport-https
+  apt-get install -y debian-keyring debian-archive-keyring apt-transport-https
   curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
   curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
-  apt -qqq update && apt -qqy upgrade
+  apt-get -qqq update && apt-get -qqy upgrade
   echo "icecast2 icecast2/icecast-setup boolean false" | debconf-set-selections
-  apt install -qqy caddy ftpd sqlite3 php-sqlite3 alsa-utils \
+  apt-get install -qqy caddy ftpd sqlite3 php-sqlite3 alsa-utils \
     pulseaudio avahi-utils sox libsox-fmt-mp3 php php-fpm php-curl php-xml \
     php-zip icecast2 swig ffmpeg wget unzip curl cmake make bc libjpeg-dev \
     zlib1g-dev python3-dev python3-pip python3-venv lsof net-tools
+  if $INSTALL_PULSEAUDIO; then
+    apt-get install -qqy pulseaudio
+  fi
 }
 
 

--- a/scripts/install_services.sh
+++ b/scripts/install_services.sh
@@ -18,7 +18,7 @@ install_depends() {
   apt-get -qqq update && apt-get -qqy upgrade
   echo "icecast2 icecast2/icecast-setup boolean false" | debconf-set-selections
   apt-get install -qqy caddy ftpd sqlite3 php-sqlite3 alsa-utils \
-    pulseaudio avahi-utils sox libsox-fmt-mp3 php php-fpm php-curl php-xml \
+    avahi-utils sox libsox-fmt-mp3 php php-fpm php-curl php-xml \
     php-zip icecast2 swig ffmpeg wget unzip curl cmake make bc libjpeg-dev \
     zlib1g-dev python3-dev python3-pip python3-venv lsof net-tools
   if $INSTALL_PULSEAUDIO; then


### PR DESCRIPTION
This adds an option to use a static ffmpeg build from a reasonably well known source instead of the native debian packages. The latter pull in a lot of dependencies, particularly for video/3D acceleration libraries which we don't use. Combining this with the option to omit pulseaudio seems to save me 0.9-1.0GB.

This PR includes the changes in #974 as it doesn't apply cleanly otherwise, but I can re-do it without if preferred.

This is the low-hanging fruit for container size - any other work I do on this I will stack up on a single branch or PR to avoid flooding you!