### PR TITLE
Allow passing extra recording options to ffmpeg

### DIFF
--- a/birdnet.conf-defaults
+++ b/birdnet.conf-defaults
@@ -68,6 +68,11 @@ BIRDNETPI_URL=
 
 RTSP_STREAM=
 
+## extra options to pass to ffmpeg for RTSP recording, this can be useful
+## e.g. to force a specific transport
+
+RTSP_REC_OPTS=
+
 #-----------------------  Apprise Miscellanous Configuration -------------------#
 
 APPRISE_NOTIFICATION_TITLE="New BirdNET-Pi Detection"

--- a/scripts/birdnet_recording.sh
+++ b/scripts/birdnet_recording.sh
@@ -42,7 +42,7 @@ if [ ! -z $RTSP_STREAM ];then
 
   # Make sure were passing something valid to ffmpeg, ffmpeg will run interactive and control our loop by waiting ${RECORDING_LENGTH} between loops because it will stop once that much has been recorded
   if [ -n "$FFMPEG_PARAMS" ];then
-    ffmpeg -hide_banner -loglevel $LOGGING_LEVEL -nostdin $FFMPEG_PARAMS
+    ffmpeg $RTSP_REC_OPTS -hide_banner -loglevel $LOGGING_LEVEL -nostdin $FFMPEG_PARAMS
   fi
 
   done

--- a/scripts/install_config.sh
+++ b/scripts/install_config.sh
@@ -96,6 +96,11 @@ BIRDNETPI_URL=
 
 RTSP_STREAM=
 
+## extra options to pass to ffmpeg for RTSP recording, this can be useful
+## e.g. to force a specific transport
+
+RTSP_REC_OPTS=
+
 #-----------------------  Apprise Miscellanous Configuration -------------------#
 
 APPRISE_NOTIFICATION_TITLE="New BirdNET-Pi Detection"


### PR DESCRIPTION
Add option to allow passing extra options to ffmpeg when recording RTSP streams (e.g. to force a specific transport.)

I needed this to pass "-rtsp_transport tcp" to make recording work from inside a rootless podman container - it uses slirp4netns and for some UDP wasn't working.
