### PR TITLE
Chunk analysis calls to facilitate recovery from stalls & low disk space

### DIFF
--- a/scripts/birdnet_analysis.sh
+++ b/scripts/birdnet_analysis.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env -S --default-signal=PIPE bash
 # Runs BirdNET-Lite
 #set -x
 source /etc/birdnet/birdnet.conf
@@ -52,6 +52,7 @@ fi
 get_files() {
   files=($( find ${1} -maxdepth 1 -name '*wav' ! -size 0\
   | sort \
+  | head -n 20 \
   | awk -F "/" '{print $NF}' ))
   [ -n "${files[1]}" ] && echo "Files loaded"
 }


### PR DESCRIPTION
In certain situations trying to recover from stalled analysis we can end up with low / no disk space and be unable to "escape." In the event of a backlog, the loop in birdnet_analysis.sh runs continuously, which means analyzed files do not get moved, which means in turn extract_new_birdsounds.sh cannot create mp3 extractions and move the processed files again, which would allow them to be cleaned up by the cron jobs.

This PR is the obvious fix, i.e. to just limit the maximum amount of files birdnet_analysis.sh can process in one invocation to 20. This should be a good trade off given the small overhead of listing files etc before the main loop begins - note that for the "normal" case of no backlog, birdnet_analysis usually exits after a single analysis anyway.