### PR TITLE
Add lazy loading of images on long play-lists

### DIFF
--- a/scripts/play.php
+++ b/scripts/play.php
@@ -523,7 +523,7 @@ echo "<table>
     if($num_rows < 100){
       $imageelem = "<video onplay='setLiveStreamVolume(0)' onended='setLiveStreamVolume(1)' onpause='setLiveStreamVolume(1)' controls poster=\"$filename_png\" preload=\"none\" title=\"$filename\"><source src=\"$filename\"></video>";
     } else {
-      $imageelem = "<a href=\"$filename\"><img src=\"$filename_png\"></a>";
+      $imageelem = "<a href=\"$filename\"><img loading=\"lazy\" src=\"$filename_png\"></a>";
     }
 
     if($config["FULL_DISK"] == "purge") {


### PR DESCRIPTION
Asking my pi to do ~4500 image requests, downloading 1,3GB of images is.. slow :)

`loading="lazy"` is a built in browser mechanism that delays image loading until it's in the viewport [See link](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading) and demo site [here](https://mathiasbynens.be/demo/img-loading-lazy)