### PR TITLE
Correct typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Currently listening in these countries . . . that I know of . . .
 - Colombia
 - Estonia
 - Tasmania
-- Luxembourgh
+- Luxembourg
 - Crete
 - Rwanda
 - Oman


### PR DESCRIPTION
Corrected typo "Luxembourgh" to "Luxembourg" in the "Currently listening" section.